### PR TITLE
Remove re2c and libxml2-dev from CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,7 @@ jobs:
         run: |
           sudo apt-get -y install \
             build-essential \
-            re2c \
             bison \
-            libxml2-dev \
             libssl-dev \
             libpcre++-dev \
             libsqlite3-dev \


### PR DESCRIPTION
These can be automatically downloaded if not found on the system.