### PR TITLE
Enable OBJECT and STATIC libraries for Zend and extensions

### DIFF
--- a/cmake/ext/CMakeLists.txt
+++ b/cmake/ext/CMakeLists.txt
@@ -78,57 +78,73 @@ add_library(PHP::extensions ALIAS php_extensions)
 # Add subdirectories of extensions.
 foreach(extension IN LISTS extensions)
   list(APPEND CMAKE_MESSAGE_CONTEXT "${extension}")
+
   message(CHECK_START "Configuring extension ${extension}")
   list(APPEND CMAKE_MESSAGE_INDENT "  ")
-
   add_subdirectory("${extension}")
-
   php_extensions_postconfigure("${extension}")
-
   list(POP_BACK CMAKE_MESSAGE_INDENT)
-  if(TARGET php_${extension})
-    set_property(GLOBAL APPEND PROPERTY PHP_EXTENSIONS ${extension})
 
-    # Add extension's PUBLIC/INTERFACE compile properties to configuration.
-    # Cleaner COMPILE_ONLY generator expression is available in CMake >= 3.27.
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
-      target_link_libraries(
-        php_configuration
-        INTERFACE
-          $<COMPILE_ONLY:PHP::${extension}>
-      )
-    else()
-      # TODO: Fix this better. Either require 3.27, or limit/adjust compile
-      # properties propagated globally. Also, shared extensions shouldn't
-      # propagate globally.
-      # https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#id36
-      target_include_directories(
-        php_configuration
-        INTERFACE
-          $<TARGET_PROPERTY:PHP::${extension},INTERFACE_INCLUDE_DIRECTORIES>
-      )
-    endif()
+  if(NOT TARGET php_${extension})
+    message(CHECK_FAIL "disabled")
+    list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+    continue()
+  endif()
 
-    target_link_libraries(php_${extension} PRIVATE PHP::configuration)
+  set_property(GLOBAL APPEND PROPERTY PHP_EXTENSIONS ${extension})
 
-    # Add configuration compile options before the extension compile options.
-    target_compile_options(
-      php_${extension}
-      BEFORE PRIVATE
-        $<TARGET_PROPERTY:php_configuration,INTERFACE_COMPILE_OPTIONS>
+  add_dependencies(php_${extension} Zend::Zend)
+
+  # Add extension's PUBLIC/INTERFACE compile properties to configuration.
+  # Cleaner COMPILE_ONLY generator expression is available in CMake >= 3.27.
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+    target_link_libraries(
+      php_configuration
+      INTERFACE
+        $<COMPILE_ONLY:PHP::${extension}>
+    )
+  else()
+    # TODO: Fix this better. Either require 3.27, or limit/adjust compile
+    # properties propagated globally. Also, shared extensions shouldn't
+    # propagate globally.
+    # https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#id36
+    target_include_directories(
+      php_configuration
+      INTERFACE
+        $<TARGET_PROPERTY:PHP::${extension},INTERFACE_INCLUDE_DIRECTORIES>
+    )
+  endif()
+
+  target_link_libraries(php_${extension} PRIVATE PHP::configuration)
+
+  # Add configuration compile options before the extension compile options.
+  target_compile_options(
+    php_${extension}
+    BEFORE PRIVATE
+      $<TARGET_PROPERTY:php_configuration,INTERFACE_COMPILE_OPTIONS>
+  )
+
+  get_target_property(type php_${extension} TYPE)
+  if(NOT type MATCHES "^(MODULE|SHARED)_LIBRARY$")
+    target_link_libraries(
+      php_extensions
+      INTERFACE
+        # If extension is STATIC library link as whole archive, otherwise link
+        # normally:
+        $<IF:$<STREQUAL:$<TARGET_PROPERTY:PHP::${extension},TYPE>,STATIC_LIBRARY>,$<LINK_LIBRARY:WHOLE_ARCHIVE,PHP::${extension}>,PHP::${extension}>
     )
 
-    add_dependencies(php_${extension} Zend::Zend)
-
-    get_target_property(type php_${extension} TYPE)
-    if(NOT type MATCHES "^(MODULE|SHARED)_LIBRARY$")
-      target_link_libraries(php_extensions INTERFACE PHP::${extension})
-    endif()
-
-    message(CHECK_PASS "enabled")
-  else()
-    message(CHECK_FAIL "disabled")
+    target_sources(
+      php_extensions
+      INTERFACE
+        # If extension is OBJECT library:
+        $<$<STREQUAL:$<TARGET_PROPERTY:PHP::${extension},TYPE>,OBJECT_LIBRARY>:$<TARGET_OBJECTS:PHP::${extension}>>
+        # If extension and linked target (SAPI) are both STATIC libraries:
+        $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>,$<STREQUAL:$<TARGET_PROPERTY:PHP::${extension},TYPE>,STATIC_LIBRARY>>:$<TARGET_OBJECTS:PHP::${extension}>>
+    )
   endif()
+
+  message(CHECK_PASS "enabled")
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endforeach()
 

--- a/cmake/ext/date/CMakeLists.txt
+++ b/cmake/ext/date/CMakeLists.txt
@@ -25,7 +25,7 @@ add_feature_info(
 # Check for headers needed by timelib.
 check_include_file(io.h HAVE_IO_H)
 
-add_library(php_date STATIC)
+add_library(php_date OBJECT)
 
 target_sources(
   php_date

--- a/cmake/ext/hash/CMakeLists.txt
+++ b/cmake/ext/hash/CMakeLists.txt
@@ -47,7 +47,7 @@ if(EXT_HASH_MHASH)
   set(PHP_MHASH_BC TRUE)
 endif()
 
-add_library(php_hash STATIC)
+add_library(php_hash OBJECT)
 
 target_sources(
   php_hash

--- a/cmake/ext/json/CMakeLists.txt
+++ b/cmake/ext/json/CMakeLists.txt
@@ -20,7 +20,7 @@ add_feature_info(
   "JavaScript Object Notation"
 )
 
-add_library(php_json STATIC)
+add_library(php_json OBJECT)
 
 target_sources(
   php_json

--- a/cmake/ext/pcre/CMakeLists.txt
+++ b/cmake/ext/pcre/CMakeLists.txt
@@ -63,7 +63,7 @@ option(
 
 mark_as_advanced(EXT_PCRE_EXTERNAL EXT_PCRE_JIT)
 
-add_library(php_pcre STATIC)
+add_library(php_pcre OBJECT)
 
 target_sources(
   php_pcre

--- a/cmake/ext/random/CMakeLists.txt
+++ b/cmake/ext/random/CMakeLists.txt
@@ -22,7 +22,7 @@ add_feature_info(
   "random number generators and functions related to randomness"
 )
 
-add_library(php_random STATIC)
+add_library(php_random OBJECT)
 
 target_sources(
   php_random

--- a/cmake/ext/reflection/CMakeLists.txt
+++ b/cmake/ext/reflection/CMakeLists.txt
@@ -20,7 +20,7 @@ add_feature_info(
   "reflection API to introspect PHP code"
 )
 
-add_library(php_reflection STATIC)
+add_library(php_reflection OBJECT)
 target_sources(
   php_reflection
   PRIVATE

--- a/cmake/ext/spl/CMakeLists.txt
+++ b/cmake/ext/spl/CMakeLists.txt
@@ -19,7 +19,7 @@ add_feature_info(
   "Standard PHP library (SPL)"
 )
 
-add_library(php_spl STATIC)
+add_library(php_spl OBJECT)
 
 target_sources(
   php_spl

--- a/cmake/ext/standard/CMakeLists.txt
+++ b/cmake/ext/standard/CMakeLists.txt
@@ -60,7 +60,7 @@ add_feature_info(
 # Add library.
 ################################################################################
 
-add_library(php_standard STATIC)
+add_library(php_standard OBJECT)
 
 target_sources(
   php_standard

--- a/cmake/main/CMakeLists.txt
+++ b/cmake/main/CMakeLists.txt
@@ -163,7 +163,8 @@ target_link_libraries(
   INTERFACE
     PHP::configuration
     php_main
-    Zend::Zend
+    # If Zend is STATIC library link as whole archive, otherwise link normally.
+    $<IF:$<STREQUAL:$<TARGET_PROPERTY:Zend::Zend,TYPE>,STATIC_LIBRARY>,$<LINK_LIBRARY:WHOLE_ARCHIVE,Zend::Zend>,Zend::Zend>
     $<$<TARGET_EXISTS:PHP::windows>::PHP::windows>
     PHP::extensions
 )
@@ -176,9 +177,17 @@ target_sources(
   php
   INTERFACE
     $<TARGET_OBJECTS:php_main>
+
     # Internal functions objects based on the SAPI type.
     $<IF:$<BOOL:$<TARGET_PROPERTY:PHP_SAPI_CLI>>,$<TARGET_OBJECTS:php_main_internal_functions_cli>,$<TARGET_OBJECTS:php_main_internal_functions>>
-    $<TARGET_OBJECTS:Zend::Zend>
+
+    # If Zend is OBJECT library, add library objects as sources.
+    $<$<STREQUAL:$<TARGET_PROPERTY:Zend::Zend,TYPE>,OBJECT_LIBRARY>:$<TARGET_OBJECTS:Zend::Zend>>
+
+    # If Zend is STATIC library, and linking to a STATIC library (SAPI), add
+    # library objects as sources.
+    $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>,$<STREQUAL:$<TARGET_PROPERTY:Zend::Zend,TYPE>,STATIC_LIBRARY>>:$<TARGET_OBJECTS:Zend::Zend>>
+
     $<$<TARGET_EXISTS:PHP::windows>:$<TARGET_OBJECTS:PHP::windows>>
 )
 


### PR DESCRIPTION
This is for testing purposes for now and to see how this behaves and if this would work ok. This enables having extensions, as STATIC, SHARED, MODULE, and OBJECT libraries. And Zend can be also STATIC.

STATIC libraries are linked with WHOLE_ARCHIVE feature (--whole-archive and other linker flags) but this is more like a cutting edge feature of linkers and probably not yet very portable solution, so Zend OBJECT library is still a better way here to go with current state of the php-src.

Additionally, always enabled extensions are marked as OBJECT libraries to make it clearer.

Fixes GH-3