### PR TITLE
Rename SAPI_<SAPI_NAME> variables to PHP_SAPI_<SAPI_NAME>

### DIFF
--- a/cmake/cmake/presets/all-disabled.json
+++ b/cmake/cmake/presets/all-disabled.json
@@ -28,8 +28,8 @@
         "EXT_XMLREADER": false,
         "EXT_XMLWRITER": false,
 
-        "SAPI_CGI": false,
-        "SAPI_PHPDBG": false
+        "PHP_SAPI_CGI": false,
+        "PHP_SAPI_PHPDBG": false
       }
     },
     {

--- a/cmake/cmake/presets/all-enabled.json
+++ b/cmake/cmake/presets/all-enabled.json
@@ -70,13 +70,13 @@
         "EXT_ZIP": true,
         "EXT_ZLIB": true,
 
-        "SAPI_EMBED": true,
-        "SAPI_FPM": true,
-        "SAPI_FPM_ACL": true,
-        "SAPI_FPM_APPARMOR": true,
-        "SAPI_FPM_SELINUX": true,
-        "SAPI_FPM_SYSTEMD": true,
-        "SAPI_LITESPEED": true
+        "PHP_SAPI_EMBED": true,
+        "PHP_SAPI_FPM": true,
+        "PHP_SAPI_FPM_ACL": true,
+        "PHP_SAPI_FPM_APPARMOR": true,
+        "PHP_SAPI_FPM_SELINUX": true,
+        "PHP_SAPI_FPM_SYSTEMD": true,
+        "PHP_SAPI_LITESPEED": true
       }
     },
     {

--- a/cmake/pear/CMakeLists.txt
+++ b/cmake/pear/CMakeLists.txt
@@ -100,8 +100,8 @@ block()
   if(NOT TARGET PHP::SAPI::cli)
     message(
       FATAL_ERROR
-      "The 'PHP_PEAR' option requires PHP CLI SAPI. Please, set 'SAPI_CLI' to "
-      "'ON'."
+      "The 'PHP_PEAR' option requires PHP CLI SAPI. Please, set 'PHP_SAPI_CLI' "
+      "to 'ON'."
     )
   endif()
 

--- a/cmake/sapi/apache2handler/CMakeLists.txt
+++ b/cmake/sapi/apache2handler/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 Configure the `apache2handler` PHP SAPI.
 
-## SAPI_APACHE2HANDLER
+## PHP_SAPI_APACHE2HANDLER
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -30,15 +30,15 @@ cmake -B php-build -DAPACHE2HANDLER=ON -DApache_EXECUTABLE=/opt/apache2/bin/apxs
 
 include(FeatureSummary)
 
-option(SAPI_APACHE2HANDLER "Enable the shared Apache 2 handler SAPI module")
+option(PHP_SAPI_APACHE2HANDLER "Enable the shared Apache 2 handler SAPI module")
 
 add_feature_info(
   "sapi/apache2handler"
-  SAPI_APACHE2HANDLER
+  PHP_SAPI_APACHE2HANDLER
   "Apache HTTP server module"
 )
 
-if(NOT SAPI_APACHE2HANDLER)
+if(NOT PHP_SAPI_APACHE2HANDLER)
   return()
 endif()
 

--- a/cmake/sapi/apache2handler/CMakeLists.txt
+++ b/cmake/sapi/apache2handler/CMakeLists.txt
@@ -88,9 +88,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX" AND EXISTS ${Apache_LIBEXECDIR}/httpd.exp)
   check_linker_flag(
     C
     "LINKER:-brtl;LINKER:-bI${Apache_LIBEXECDIR}/httpd.exp"
-    _HAVE_BRTL_FLAG_C
+    _PHP_HAVE_BRTL_FLAG_C
   )
-  if(_HAVE_BRTL_FLAG_C)
+  if(_PHP_HAVE_BRTL_FLAG_C)
     target_link_options(
       php_sapi_apache2handler
       PRIVATE

--- a/cmake/sapi/cgi/CMakeLists.txt
+++ b/cmake/sapi/cgi/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 Configure the `cgi` PHP SAPI.
 
-## SAPI_CGI
+## PHP_SAPI_CGI
 
 * Default: `ON`
 * Values: `ON|OFF`
@@ -14,15 +14,15 @@ Enable the PHP CGI (Common Gateway Interface) SAPI executable module.
 include(CheckStructHasMember)
 include(FeatureSummary)
 
-option(SAPI_CGI "Enable the CGI (Common Gateway Interface) SAPI" ON)
+option(PHP_SAPI_CGI "Enable the CGI (Common Gateway Interface) SAPI" ON)
 
 add_feature_info(
   "sapi/cgi"
-  SAPI_CGI
+  PHP_SAPI_CGI
   "Common Gateway Interface executable"
 )
 
-if(NOT SAPI_CGI)
+if(NOT PHP_SAPI_CGI)
   return()
 endif()
 

--- a/cmake/sapi/cli/CMakeLists.txt
+++ b/cmake/sapi/cli/CMakeLists.txt
@@ -15,8 +15,8 @@ Enable the PHP CLI (Command-Line Interpreter/Interface) SAPI executable module.
 * Default: `OFF`
 * Values: `ON|OFF`
 
-Build console-less CLI SAPI. Same as the main CLI SAPI but without console (no
-output is given).
+Build additional console-less CLI SAPI executable (executable name `php-win`).
+Same as the main CLI SAPI (`php`) but without the console (no output is given).
 
 > [!NOTE]
 > This option is only available when the target system is Windows.
@@ -131,11 +131,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 if(PHP_SAPI_CLI_WIN_NO_CONSOLE)
-  add_executable(php_sapi_cli_win_no_console)
-  add_executable(PHP::SAPI::cli_win_no_console ALIAS php_sapi_cli_win_no_console)
+  add_executable(php_sapi_cli_win)
+  add_executable(PHP::SAPI::cli_win ALIAS php_sapi_cli_win)
 
   target_sources(
-    php_sapi_cli_win_no_console
+    php_sapi_cli_win
     PRIVATE
       cli_win32.c
       php_cli_process_title.c
@@ -144,26 +144,26 @@ if(PHP_SAPI_CLI_WIN_NO_CONSOLE)
   )
 
   set_target_properties(
-    php_sapi_cli_win_no_console
+    php_sapi_cli_win
     PROPERTIES
       OUTPUT_NAME ${PHP_PROGRAM_PREFIX}php-win${PHP_PROGRAM_SUFFIX}
   )
 
   target_compile_definitions(
-    php_sapi_cli_win_no_console
+    php_sapi_cli_win
     PRIVATE
       ZEND_ENABLE_STATIC_TSRMLS_CACHE
   )
 
   target_link_libraries(
-    php_sapi_cli_win_no_console
+    php_sapi_cli_win
     PRIVATE
       PHP::SAPI
       shell32
   )
 
   target_link_options(
-    php_sapi_cli_win_no_console
+    php_sapi_cli_win
     PRIVATE
       /stack:67108864
   )

--- a/cmake/sapi/cli/CMakeLists.txt
+++ b/cmake/sapi/cli/CMakeLists.txt
@@ -3,14 +3,14 @@
 
 Configure the `cli` PHP SAPI.
 
-## SAPI_CLI
+## PHP_SAPI_CLI
 
 * Default: `ON`
 * Values: `ON|OFF`
 
 Enable the PHP CLI (Command-Line Interpreter/Interface) SAPI executable module.
 
-## SAPI_CLI_WIN_NO_CONSOLE
+## PHP_SAPI_CLI_WIN_NO_CONSOLE
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -28,27 +28,27 @@ include(CheckSymbolExists)
 include(CMakeDependentOption)
 include(FeatureSummary)
 
-option(SAPI_CLI "Enable the CLI SAPI module" ON)
+option(PHP_SAPI_CLI "Enable the CLI SAPI module" ON)
 add_feature_info(
   "sapi/cli"
-  SAPI_CLI
+  PHP_SAPI_CLI
   "Command-Line Interpreter/Interface executable"
 )
 
 cmake_dependent_option(
-  SAPI_CLI_WIN_NO_CONSOLE
+  PHP_SAPI_CLI_WIN_NO_CONSOLE
   "Build additional CLI SAPI without console (no output is given)"
   OFF
-  [[SAPI_CLI AND CMAKE_SYSTEM_NAME STREQUAL "Windows"]]
+  [[PHP_SAPI_CLI AND CMAKE_SYSTEM_NAME STREQUAL "Windows"]]
   OFF
 )
 add_feature_info(
   "sapi/cli console-less"
-  SAPI_CLI_WIN_NO_CONSOLE
+  PHP_SAPI_CLI_WIN_NO_CONSOLE
   "additional executable without console output"
 )
 
-if(NOT SAPI_CLI)
+if(NOT PHP_SAPI_CLI)
   return()
 endif()
 
@@ -130,7 +130,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   )
 endif()
 
-if(SAPI_CLI_WIN_NO_CONSOLE)
+if(PHP_SAPI_CLI_WIN_NO_CONSOLE)
   add_executable(php_sapi_cli_win_no_console)
   add_executable(PHP::SAPI::cli_win_no_console ALIAS php_sapi_cli_win_no_console)
 

--- a/cmake/sapi/embed/CMakeLists.txt
+++ b/cmake/sapi/embed/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 Configure the `embed` PHP SAPI.
 
-## SAPI_EMBED
+## PHP_SAPI_EMBED
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -19,15 +19,15 @@ to use PHP.
 
 include(FeatureSummary)
 
-option(SAPI_EMBED "Enable the Embed SAPI module")
+option(PHP_SAPI_EMBED "Enable the Embed SAPI module")
 
 add_feature_info(
   "sapi/embed"
-  SAPI_EMBED
+  PHP_SAPI_EMBED
   "module for embedding PHP into application"
 )
 
-if(NOT SAPI_EMBED)
+if(NOT PHP_SAPI_EMBED)
   return()
 endif()
 

--- a/cmake/sapi/fpm/CMakeLists.txt
+++ b/cmake/sapi/fpm/CMakeLists.txt
@@ -6,27 +6,27 @@ Configure the `fpm` PHP SAPI.
 > [!NOTE]
 > PHP FPM is not available when the target system is Windows.
 
-## SAPI_FPM
+## PHP_SAPI_FPM
 
 * Default: `OFF`
 * Values: `ON|OFF`
 
 Enable the FastCGI Process Manager (FPM) SAPI module.
 
-## SAPI_FPM_USER
+## PHP_SAPI_FPM_USER
 
 * Default: `nobody`
 
 Set the user for running PHP FPM.
 
-## SAPI_FPM_GROUP
+## PHP_SAPI_FPM_GROUP
 
 * Default: `nobody`
 
 Set the group for running PHP FPM. For a system user, this should usually be set
 in a way to match the FPM username.
 
-## SAPI_FPM_ACL
+## PHP_SAPI_FPM_ACL
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -40,7 +40,7 @@ Where to find ACL installation on the system, can be customized with the
 > This option is not available when the target system is Darwin (macOS) as this
 > system doesn't have ACL.
 
-## SAPI_FPM_APPARMOR
+## PHP_SAPI_FPM_APPARMOR
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -54,7 +54,7 @@ Where to find AppArmor installation on the system, can be customized with the
 > This option is not available when the target system is Darwin (macOS) as this
 > system doesn't have AppArmor.
 
-## SAPI_FPM_SELINUX
+## PHP_SAPI_FPM_SELINUX
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -68,7 +68,7 @@ Where to find SELinux installation on the system, can be customized with the
 > This option is not available when the target system is Darwin (macOS) as this
 > system doesn't have SELinux.
 
-## SAPI_FPM_SYSTEMD
+## PHP_SAPI_FPM_SYSTEMD
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -102,25 +102,25 @@ include(PHP/Set)
 # FPM configuration.
 ################################################################################
 
-option(SAPI_FPM "Enable the FPM SAPI module")
+option(PHP_SAPI_FPM "Enable the FPM SAPI module")
 add_feature_info(
   "sapi/fpm"
-  SAPI_FPM
+  PHP_SAPI_FPM
   "FastCGI Process Manager"
 )
 
 php_set(
-  SAPI_FPM_USER
+  PHP_SAPI_FPM_USER
   TYPE STRING
-  IF SAPI_FPM
+  IF PHP_SAPI_FPM
   VALUE "nobody"
   DOC "Set the user for running PHP FPM (default: nobody)"
 )
 
 php_set(
-  SAPI_FPM_GROUP
+  PHP_SAPI_FPM_GROUP
   TYPE STRING
-  IF SAPI_FPM
+  IF PHP_SAPI_FPM
   VALUE "nobody"
   DOC
     "Set the group for running PHP FPM. For a system user, this should usually "
@@ -128,58 +128,58 @@ php_set(
 )
 
 php_set(
-  SAPI_FPM_ACL
+  PHP_SAPI_FPM_ACL
   TYPE BOOL
-  IF [[SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
+  IF [[PHP_SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
   VALUE OFF
   DOC "Use POSIX Access Control Lists"
 )
 add_feature_info(
   "sapi/fpm ACL"
-  SAPI_FPM_ACL
+  PHP_SAPI_FPM_ACL
   "POSIX Access Control Lists integration"
 )
 
 php_set(
-  SAPI_FPM_APPARMOR
+  PHP_SAPI_FPM_APPARMOR
   TYPE BOOL
-  IF [[SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
+  IF [[PHP_SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
   VALUE OFF
   DOC "Enable the AppArmor confinement through libapparmor"
 )
 add_feature_info(
   "sapi/fpm AppArmor"
-  SAPI_FPM_APPARMOR
+  PHP_SAPI_FPM_APPARMOR
   "application confinement integration"
 )
 
 php_set(
-  SAPI_FPM_SELINUX
+  PHP_SAPI_FPM_SELINUX
   TYPE BOOL
-  IF [[SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
+  IF [[PHP_SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
   VALUE OFF
   DOC "Enable the SELinux policy library support"
 )
 add_feature_info(
   "sapi/fpm SELinux"
-  SAPI_FPM_SELINUX
+  PHP_SAPI_FPM_SELINUX
   "security policy integration"
 )
 
 php_set(
-  SAPI_FPM_SYSTEMD
+  PHP_SAPI_FPM_SYSTEMD
   TYPE BOOL
-  IF [[SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
+  IF [[PHP_SAPI_FPM AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"]]
   VALUE OFF
   DOC "Enable the systemd integration"
 )
 add_feature_info(
   "sapi/fpm systemd"
-  SAPI_FPM_SYSTEMD
+  PHP_SAPI_FPM_SYSTEMD
   "system and service manager integration"
 )
 
-if(NOT SAPI_FPM)
+if(NOT PHP_SAPI_FPM)
   return()
 endif()
 
@@ -458,7 +458,7 @@ endif()
 # Configure FPM from configuration options.
 ################################################################################
 
-if(SAPI_FPM_SYSTEMD)
+if(PHP_SAPI_FPM_SYSTEMD)
   find_package(Systemd 209)
   set_package_properties(
     Systemd
@@ -480,7 +480,7 @@ else()
   set(PHP_FPM_SYSTEMD "simple")
 endif()
 
-if(SAPI_FPM_ACL)
+if(PHP_SAPI_FPM_ACL)
   set(ACL_USE_USER_GROUP TRUE)
   find_package(ACL)
   set_package_properties(
@@ -502,7 +502,7 @@ if(SAPI_FPM_ACL)
   endif()
 endif()
 
-if(SAPI_FPM_APPARMOR)
+if(PHP_SAPI_FPM_APPARMOR)
   find_package(AppArmor)
   set_package_properties(
     AppArmor
@@ -518,7 +518,7 @@ if(SAPI_FPM_APPARMOR)
   endif()
 endif()
 
-if(SAPI_FPM_SELINUX)
+if(PHP_SAPI_FPM_SELINUX)
   find_package(SELinux)
   set_package_properties(
     SELinux
@@ -581,8 +581,8 @@ php_configure_file(
   VARIABLES
     prefix "$<INSTALL_PREFIX>"
     php_fpm_prefix "$<INSTALL_PREFIX>"
-    php_fpm_user "${SAPI_FPM_USER}"
-    php_fpm_group "${SAPI_FPM_GROUP}"
+    php_fpm_user "${PHP_SAPI_FPM_USER}"
+    php_fpm_group "${PHP_SAPI_FPM_GROUP}"
     EXPANDED_DATADIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_DATADIR},$<INSTALL_PREFIX>>"
 )
 

--- a/cmake/sapi/fuzzer/CMakeLists.txt
+++ b/cmake/sapi/fuzzer/CMakeLists.txt
@@ -6,7 +6,7 @@ Configure the `fuzzer` PHP SAPI.
 > [!NOTE]
 > This SAPI is not available when the target system is Windows.
 
-## SAPI_FUZZER
+## PHP_SAPI_FUZZER
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -33,17 +33,17 @@ include(FeatureSummary)
 include(PHP/CheckCompilerFlag)
 
 option(
-  SAPI_FUZZER
+  PHP_SAPI_FUZZER
   "Enable the fuzzer SAPI module - Clang fuzzing test module (for developers)"
 )
 
 add_feature_info(
   "sapi/fuzzer"
-  SAPI_FUZZER
+  PHP_SAPI_FUZZER
   "Clang fuzzing module"
 )
 
-if(SAPI_FUZZER)
+if(PHP_SAPI_FUZZER)
   set(
     LIB_FUZZING_ENGINE
     ""
@@ -54,7 +54,7 @@ if(SAPI_FUZZER)
   mark_as_advanced(LIB_FUZZING_ENGINE)
 endif()
 
-if(NOT SAPI_FUZZER)
+if(NOT PHP_SAPI_FUZZER)
   return()
 endif()
 
@@ -62,7 +62,7 @@ if(PHP_THREAD_SAFETY)
   message(
     FATAL_ERROR
     "Thread safety (PHP_THREAD_SAFETY) is not supported when building fuzzing "
-    "SAPI module (SAPI_FUZZER). Please build fuzzer without ZTS by setting "
+    "SAPI module (PHP_SAPI_FUZZER). Please build fuzzer without ZTS by setting "
     "PHP_THREAD_SAFETY to default 'OFF'."
   )
 endif()

--- a/cmake/sapi/fuzzer/CMakeLists.txt
+++ b/cmake/sapi/fuzzer/CMakeLists.txt
@@ -89,17 +89,17 @@ else()
     php_check_compiler_flag(
       C
       -fsanitize=fuzzer-no-link
-      HAVE_FSANITIZE_FUZZER_NO_LINK_C
+      _PHP_HAVE_FSANITIZE_FUZZER_NO_LINK_C
     )
 
     php_check_compiler_flag(
       CXX
       -fsanitize=fuzzer-no-link
-      HAVE_FSANITIZE_FUZZER_NO_LINK_CXX
+      _PHP_HAVE_FSANITIZE_FUZZER_NO_LINK_CXX
     )
   cmake_pop_check_state()
 
-  if(NOT HAVE_FSANITIZE_FUZZER_NO_LINK_C)
+  if(NOT _PHP_HAVE_FSANITIZE_FUZZER_NO_LINK_C)
     message(
       FATAL_ERROR
       "The fuzzer SAPI cannot be enabled. C compiler ${CMAKE_C_COMPILER_ID} "
@@ -107,7 +107,7 @@ else()
     )
   endif()
 
-  if(NOT HAVE_FSANITIZE_FUZZER_NO_LINK_CXX)
+  if(NOT _PHP_HAVE_FSANITIZE_FUZZER_NO_LINK_CXX)
     message(
       FATAL_ERROR
       "The fuzzer SAPI cannot be enabled. C++ compiler "

--- a/cmake/sapi/litespeed/CMakeLists.txt
+++ b/cmake/sapi/litespeed/CMakeLists.txt
@@ -6,7 +6,7 @@ Configure the `litespeed` PHP SAPI.
 > [!NOTE]
 > The PHP Litespeed SAPI is not available when the target system is Windows.
 
-## SAPI_LITESPEED
+## PHP_SAPI_LITESPEED
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -20,15 +20,15 @@ endif()
 
 include(FeatureSummary)
 
-option(SAPI_LITESPEED "Enable the LiteSpeed SAPI module")
+option(PHP_SAPI_LITESPEED "Enable the LiteSpeed SAPI module")
 
 add_feature_info(
   "sapi/litespeed"
-  SAPI_LITESPEED
+  PHP_SAPI_LITESPEED
   "LiteSpeed web server module"
 )
 
-if(NOT SAPI_LITESPEED)
+if(NOT PHP_SAPI_LITESPEED)
   return()
 endif()
 

--- a/cmake/sapi/phpdbg/CMakeLists.txt
+++ b/cmake/sapi/phpdbg/CMakeLists.txt
@@ -3,21 +3,21 @@
 
 Configure the `phpdbg` (interactive PHP debugger) PHP SAPI.
 
-## SAPI_PHPDBG
+## PHP_SAPI_PHPDBG
 
 * Default: `ON`
 * Values: `ON|OFF`
 
 Enable the phpdbg SAPI module as an executable.
 
-## SAPI_PHPDBG_SHARED
+## PHP_SAPI_PHPDBG_SHARED
 
 * Default: `OFF`
 * Values: `ON|OFF`
 
 Build phpdbg SAPI also as a shared module together with an executable.
 
-## SAPI_PHPDBG_DEBUG
+## PHP_SAPI_PHPDBG_DEBUG
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -25,7 +25,7 @@ Build phpdbg SAPI also as a shared module together with an executable.
 Build phpdbg in debug mode to enable additional diagnostic output for developing
 and troubleshooting phpdbg itself.
 
-## SAPI_PHPDBG_READLINE
+## PHP_SAPI_PHPDBG_READLINE
 
 * Default: `OFF`
 * Values: `ON|OFF`
@@ -48,51 +48,51 @@ include(PHP/Install)
 # Configuration options.
 ################################################################################
 
-option(SAPI_PHPDBG "Enable the phpdbg SAPI module" ON)
+option(PHP_SAPI_PHPDBG "Enable the phpdbg SAPI module" ON)
 add_feature_info(
   "sapi/phpdbg"
-  SAPI_PHPDBG
+  PHP_SAPI_PHPDBG
   "interactive PHP debugger"
 )
 
 cmake_dependent_option(
-  SAPI_PHPDBG_SHARED
+  PHP_SAPI_PHPDBG_SHARED
   "Build phpdbg SAPI as a shared module"
   OFF
-  "SAPI_PHPDBG"
+  "PHP_SAPI_PHPDBG"
   OFF
 )
-mark_as_advanced(SAPI_PHPDBG_SHARED)
+mark_as_advanced(PHP_SAPI_PHPDBG_SHARED)
 add_feature_info(
   "sapi/phpdbg shared"
-  SAPI_PHPDBG_SHARED
+  PHP_SAPI_PHPDBG_SHARED
   "dynamically loadable shared object"
 )
 
 cmake_dependent_option(
-  SAPI_PHPDBG_DEBUG
+  PHP_SAPI_PHPDBG_DEBUG
   "Enable additional diagnostic output when developing phpdbg itself"
   OFF
-  "SAPI_PHPDBG"
+  "PHP_SAPI_PHPDBG"
   OFF
 )
-mark_as_advanced(SAPI_PHPDBG_DEBUG)
+mark_as_advanced(PHP_SAPI_PHPDBG_DEBUG)
 add_feature_info(
   "sapi/phpdbg debug"
-  SAPI_PHPDBG_DEBUG
+  PHP_SAPI_PHPDBG_DEBUG
   "additional diagnostic output"
 )
 
 cmake_dependent_option(
-  SAPI_PHPDBG_READLINE
+  PHP_SAPI_PHPDBG_READLINE
   "Explicitly enable readline support in phpdbg"
   OFF
-  "SAPI_PHPDBG"
+  "PHP_SAPI_PHPDBG"
   OFF
 )
-mark_as_advanced(SAPI_PHPDBG_READLINE)
+mark_as_advanced(PHP_SAPI_PHPDBG_READLINE)
 
-if(NOT SAPI_PHPDBG)
+if(NOT PHP_SAPI_PHPDBG)
   return()
 endif()
 
@@ -132,7 +132,7 @@ target_compile_definitions(
   PRIVATE
     ZEND_ENABLE_STATIC_TSRMLS_CACHE
     $<$<PLATFORM_ID:Windows>:YY_NO_UNISTD_H>
-    $<IF:$<BOOL:${SAPI_PHPDBG_DEBUG}>,PHPDBG_DEBUG=1,PHPDBG_DEBUG=0>
+    $<IF:$<BOOL:${PHP_SAPI_PHPDBG_DEBUG}>,PHPDBG_DEBUG=1,PHPDBG_DEBUG=0>
 )
 
 target_link_libraries(
@@ -163,7 +163,7 @@ set_target_properties(
 
 message(CHECK_START "Checking for readline support in phpdbg")
 
-if(SAPI_PHPDBG_READLINE OR EXT_READLINE)
+if(PHP_SAPI_PHPDBG_READLINE OR EXT_READLINE)
   message(CHECK_PASS "enabled")
 
   if(EXT_READLINE_LIBREADLINE)
@@ -216,7 +216,7 @@ add_feature_info(
 ################################################################################
 
 # TODO: Should readline support be also enabled like in the executable?
-if(SAPI_PHPDBG_SHARED)
+if(PHP_SAPI_PHPDBG_SHARED)
   add_library(php_sapi_phpdbg_shared SHARED)
   add_library(PHP::SAPI::phpdbg_shared ALIAS php_sapi_phpdbg_shared)
 
@@ -229,7 +229,7 @@ if(SAPI_PHPDBG_SHARED)
     PRIVATE
       ZEND_ENABLE_STATIC_TSRMLS_CACHE
       $<$<PLATFORM_ID:Windows>:YY_NO_UNISTD_H>
-      $<IF:$<BOOL:${SAPI_PHPDBG_DEBUG}>,PHPDBG_DEBUG=1,PHPDBG_DEBUG=0>
+      $<IF:$<BOOL:${PHP_SAPI_PHPDBG_DEBUG}>,PHPDBG_DEBUG=1,PHPDBG_DEBUG=0>
   )
 
   target_link_libraries(

--- a/patches/8.3/phpdbg-prompt.patch
+++ b/patches/8.3/phpdbg-prompt.patch
@@ -18,7 +18,7 @@ Autotools:
 
 CMake:
 
-    cmake -DSAPI_PHPDBG_READLINE=ON .
+    cmake -DPHP_SAPI_PHPDBG_READLINE=ON .
     cmake --build .
     ./sapi/phpdbg/phpdbg
 

--- a/patches/8.4/phpdbg-prompt.patch
+++ b/patches/8.4/phpdbg-prompt.patch
@@ -18,7 +18,7 @@ Autotools:
 
 CMake:
 
-    cmake -DSAPI_PHPDBG_READLINE=ON .
+    cmake -DPHP_SAPI_PHPDBG_READLINE=ON .
     cmake --build .
     ./sapi/phpdbg/phpdbg
 

--- a/patches/8.5/phpdbg-prompt.patch
+++ b/patches/8.5/phpdbg-prompt.patch
@@ -18,7 +18,7 @@ Autotools:
 
 CMake:
 
-    cmake -DSAPI_PHPDBG_READLINE=ON .
+    cmake -DPHP_SAPI_PHPDBG_READLINE=ON .
     cmake --build .
     ./sapi/phpdbg/phpdbg
 


### PR DESCRIPTION
This is a first mitigation step to start taking care of the global scope annoyances.

All cache variables of some project should be scoped inside some namespace. In CMake's case, at the time of writing, this can be taken care of prefixing all variable names. For example, with 'PHP_'.

Specifically, this issue is noticed when using the CMake's `FetchContent` module, where concerns with cache variables overrides from one project to the other can happen as the same CMakeCache.txt file is used for the entire build.