### PR TITLE
Improve consecutive configuration phases

### DIFF
--- a/cmake/Zend/cmake/CheckDlsym.cmake
+++ b/cmake/Zend/cmake/CheckDlsym.cmake
@@ -7,14 +7,17 @@ Some non-ELF platforms, such as OpenBSD, FreeBSD, NetBSD, Mac OSX (~10.3),
 needed underscore character (`_`) prefix for symbols, when using `dlsym()`. This
 module is obsolete on current platforms.
 
-## Result variables
+## Cache variables
 
 * `DLSYM_NEEDS_UNDERSCORE`
-
-  Whether `dlsym()` requires a leading underscore in symbol names.
 #]=============================================================================]
 
 include_guard(GLOBAL)
+
+# Skip in consecutive configuration phases.
+if(DEFINED DLSYM_NEEDS_UNDERSCORE)
+  return()
+endif()
 
 include(CheckIncludeFile)
 
@@ -112,9 +115,17 @@ block()
   )
 endblock()
 
+set(
+  DLSYM_NEEDS_UNDERSCORE
+  ""
+  CACHE INTERNAL
+  "Whether 'dlsym()' requires a leading underscore in symbol names."
+)
+
 if(DLSYM_NEEDS_UNDERSCORE_COMPILED AND DLSYM_NEEDS_UNDERSCORE_EXITCODE EQUAL 2)
-  set(DLSYM_NEEDS_UNDERSCORE TRUE)
+  set_property(CACHE DLSYM_NEEDS_UNDERSCORE PROPERTY VALUE TRUE)
   message(CHECK_PASS "yes")
 else()
+  set_property(CACHE DLSYM_NEEDS_UNDERSCORE PROPERTY VALUE FALSE)
   message(CHECK_FAIL "no")
 endif()

--- a/cmake/Zend/cmake/CheckGlobalRegisterVariables.cmake
+++ b/cmake/Zend/cmake/CheckGlobalRegisterVariables.cmake
@@ -16,6 +16,11 @@ See also: [GCC global register variables](https://gcc.gnu.org/onlinedocs/gcc/Glo
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED HAVE_GCC_GLOBAL_REGS)
+  return()
+endif()
+
 include(CheckSourceCompiles)
 include(CMakePushCheckState)
 

--- a/cmake/Zend/cmake/CheckStackDirection.cmake
+++ b/cmake/Zend/cmake/CheckStackDirection.cmake
@@ -12,6 +12,11 @@ Check whether the stack grows downwards. Assumes contiguous stack.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED ZEND_CHECK_STACK_LIMIT)
+  return()
+endif()
+
 include(CheckSourceRuns)
 include(CMakePushCheckState)
 

--- a/cmake/Zend/cmake/MaxExecutionTimers.cmake
+++ b/cmake/Zend/cmake/MaxExecutionTimers.cmake
@@ -16,7 +16,7 @@ Check whether to enable Zend max execution timers.
 * `ZEND_MAX_EXECUTION_TIMERS`
 
   A local variable based on the cache variable and thread safety to be able to
-  run consecutive configuration runs. When `ZEND_MAX_EXECUTION_TIMERS` cache
+  run consecutive configuration phases. When `ZEND_MAX_EXECUTION_TIMERS` cache
   variable is set to 'auto', local variable default value is set to the
   `PHP_THREAD_SAFETY` value.
 

--- a/cmake/cmake/ConfigureChecks.cmake
+++ b/cmake/cmake/ConfigureChecks.cmake
@@ -138,8 +138,10 @@ cmake_pop_check_state()
 check_type_size("gid_t" SIZEOF_GID_T)
 if(NOT HAVE_SIZEOF_GID_T)
   set(
-    gid_t int
-    CACHE INTERNAL "Define as 'int' if <sys/types.h> doesn't define."
+    gid_t
+    int
+    CACHE INTERNAL
+    "Define as 'int' if not defined in <sys/types.h>."
   )
 endif()
 
@@ -204,8 +206,10 @@ endif()
 check_type_size("uid_t" SIZEOF_UID_T)
 if(NOT HAVE_SIZEOF_UID_T)
   set(
-    uid_t int
-    CACHE INTERNAL "Define as 'int' if <sys/types.h> doesn't define."
+    uid_t
+    int
+    CACHE INTERNAL
+    "Define as 'int' if not defined in <sys/types.h>."
   )
 endif()
 
@@ -438,9 +442,7 @@ endif()
 include(PHP/CheckByteOrder)
 
 # Check for IPv6 support.
-if(PHP_IPV6)
-  include(PHP/CheckIPv6)
-endif()
+include(PHP/CheckIPv6)
 
 # Check how flush should be called.
 include(PHP/CheckFlushIo)

--- a/cmake/cmake/modules/FindACL.cmake
+++ b/cmake/cmake/modules/FindACL.cmake
@@ -125,8 +125,10 @@ if(NOT DEFINED ACL_IS_BUILT_IN)
 
     if(_acl_works)
       set(
-        ACL_IS_BUILT_IN TRUE
-        CACHE INTERNAL "Whether ACL is a part of the C library"
+        ACL_IS_BUILT_IN
+        TRUE
+        CACHE INTERNAL
+        "Whether ACL is a part of the C library."
       )
     else()
       set(ACL_IS_BUILT_IN FALSE)

--- a/cmake/cmake/modules/PHP/Bison.cmake
+++ b/cmake/cmake/modules/PHP/Bison.cmake
@@ -288,14 +288,14 @@ function(php_bison name input output)
 
   _php_bison_config()
 
+  # Skip consecutive find_package() calls when:
+  # - project calls php_bison() multiple times and Bison will be downloaded
+  # - the outer find_package() was called prior to php_bison()
+  # - running consecutive configuration phases and Bison will be downloaded
   if(
-    # Skip consecutive find_package() calls when:
-    # - project calls php_bison() multiple times and Bison will be downloaded:
     NOT TARGET Bison::Bison
-    # - the outer find_package() was called prior to php_bison():
     AND NOT DEFINED BISON_FOUND
-    # - running consecutive configuration phases:
-    AND NOT BISON_EXECUTABLE
+    AND NOT _PHP_BISON_DOWNLOAD
   )
     find_package(BISON ${PHP_BISON_VERSION} ${quiet})
   endif()
@@ -649,6 +649,13 @@ function(_php_bison_download)
   set_property(GLOBAL PROPERTY PACKAGES_NOT_FOUND packagesNotFound)
   get_property(packagesFound GLOBAL PROPERTY PACKAGES_FOUND)
   set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND BISON)
+
+  set(
+    _PHP_BISON_DOWNLOAD
+    TRUE
+    CACHE INTERNAL
+    "Internal marker whether the Bison will be downloaded."
+  )
 
   return(PROPAGATE BISON_FOUND BISON_VERSION)
 endfunction()

--- a/cmake/cmake/modules/PHP/CheckAVX512.cmake
+++ b/cmake/cmake/modules/PHP/CheckAVX512.cmake
@@ -20,6 +20,11 @@ TODO: Adjust checks for MSVC.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_HAVE_AVX512_SUPPORTS AND DEFINED PHP_HAVE_AVX512_VBMI_SUPPORTS)
+  return()
+endif()
+
 include(CheckSourceCompiles)
 include(CMakePushCheckState)
 

--- a/cmake/cmake/modules/PHP/CheckAttribute.cmake
+++ b/cmake/cmake/modules/PHP/CheckAttribute.cmake
@@ -103,6 +103,11 @@ function(_php_check_attribute what attribute result)
     message(FATAL_ERROR "Wrong argument passed: ${what}")
   endif()
 
+  # Skip in consecutive configuration phases.
+  if(DEFINED ${result})
+    return()
+  endif()
+
   message(CHECK_START "Checking for ${what} attribute ${attribute}")
 
   cmake_push_check_state(RESET)

--- a/cmake/cmake/modules/PHP/CheckBrokenGccStrlenOpt.cmake
+++ b/cmake/cmake/modules/PHP/CheckBrokenGccStrlenOpt.cmake
@@ -15,6 +15,11 @@ See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86914
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_HAVE_BROKEN_OPTIMIZE_STRLEN)
+  return()
+endif()
+
 include(CheckSourceRuns)
 include(CMakePushCheckState)
 

--- a/cmake/cmake/modules/PHP/CheckBuiltin.cmake
+++ b/cmake/cmake/modules/PHP/CheckBuiltin.cmake
@@ -27,6 +27,11 @@ include(CheckSourceCompiles)
 include(CMakePushCheckState)
 
 function(php_check_builtin builtin result)
+  # Skip in consecutive configuration phases.
+  if(DEFINED ${result})
+    return()
+  endif()
+
   message(CHECK_START "Checking for ${builtin}")
 
   if(builtin STREQUAL "__builtin_clz")

--- a/cmake/cmake/modules/PHP/CheckByteOrder.cmake
+++ b/cmake/cmake/modules/PHP/CheckByteOrder.cmake
@@ -10,14 +10,30 @@ Check whether system byte ordering is big-endian.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED WORDS_BIGENDIAN)
+  return()
+endif()
+
 include(CheckSourceRuns)
 
 message(CHECK_START "Checking byte ordering")
 
 if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
   message(CHECK_PASS "big-endian")
-  set(WORDS_BIGENDIAN TRUE CACHE INTERNAL "Whether byte ordering is big-endian.")
+  set(
+    WORDS_BIGENDIAN
+    TRUE
+    CACHE INTERNAL
+    "Whether byte ordering is big-endian."
+  )
 elseif(CMAKE_C_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+  set(
+    WORDS_BIGENDIAN
+    FALSE
+    CACHE INTERNAL
+    "Whether byte ordering is big-endian."
+  )
   message(CHECK_PASS "little-endian")
 else()
   if(

--- a/cmake/cmake/modules/PHP/CheckCompilerFlag.cmake
+++ b/cmake/cmake/modules/PHP/CheckCompilerFlag.cmake
@@ -65,6 +65,11 @@ function(php_check_compiler_flag lang flag result)
     message(FATAL_ERROR "Missing arguments.")
   endif()
 
+  # Skip in consecutive configuration phases.
+  if(DEFINED ${result})
+    return()
+  endif()
+
   if(NOT CMAKE_REQUIRED_QUIET)
     message(CHECK_START "Checking whether the ${lang} compiler accepts ${flag}")
   endif()

--- a/cmake/cmake/modules/PHP/CheckCopyFileRange.cmake
+++ b/cmake/cmake/modules/PHP/CheckCopyFileRange.cmake
@@ -14,6 +14,11 @@ only on Linux.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED HAVE_COPY_FILE_RANGE)
+  return()
+endif()
+
 include(CheckSourceCompiles)
 include(CMakePushCheckState)
 

--- a/cmake/cmake/modules/PHP/CheckFlushIo.cmake
+++ b/cmake/cmake/modules/PHP/CheckFlushIo.cmake
@@ -6,11 +6,14 @@ Check if flush should be called explicitly after buffered io.
 ## Cache variables
 
 * `HAVE_FLUSHIO`
-
-  Whether flush should be called explicitly after a buffered io.
 #]=============================================================================]
 
 include_guard(GLOBAL)
+
+# Skip in consecutive configuration phases.
+if(DEFINED HAVE_FLUSHIO)
+  return()
+endif()
 
 include(CheckIncludeFile)
 include(CheckSourceRuns)
@@ -22,7 +25,12 @@ message(CHECK_START
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   message(CHECK_FAIL "no")
-  set(HAVE_FLUSHIO FALSE CACHE INTERNAL "")
+  set(
+    HAVE_FLUSHIO
+    FALSE
+    CACHE INTERNAL
+    "Whether flush should be called explicitly after a buffered io."
+  )
   return()
 endif()
 

--- a/cmake/cmake/modules/PHP/CheckFopencookie.cmake
+++ b/cmake/cmake/modules/PHP/CheckFopencookie.cmake
@@ -47,6 +47,11 @@ if(NOT HAVE_FOPENCOOKIE)
   return()
 endif()
 
+# Skip in consecutive configuration phases.
+if(DEFINED COOKIE_SEEKER_USES_OFF64_T)
+  return()
+endif()
+
 # GNU C library can have a different seeker definition using off64_t.
 message(CHECK_START "Checking whether fopencookie seeker uses off64_t")
 

--- a/cmake/cmake/modules/PHP/CheckIPv6.cmake
+++ b/cmake/cmake/modules/PHP/CheckIPv6.cmake
@@ -3,19 +3,24 @@
 
 Check for IPv6 support.
 
-## Cache variables
+## Result variables
 
 * `HAVE_IPV6`
 
-  Whether IPv6 support is enabled.
+  Whether IPv6 support is supported and enabled.
 #]=============================================================================]
-
-include_guard(GLOBAL)
 
 include(CheckSourceCompiles)
 include(CMakePushCheckState)
 
+set(HAVE_IPV6 FALSE)
+
 message(CHECK_START "Checking for IPv6 support")
+
+if(NOT PHP_IPV6)
+  message(CHECK_FAIL "no")
+  return()
+endif()
 
 cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_QUIET TRUE)
@@ -36,10 +41,11 @@ cmake_push_check_state(RESET)
 
       return 0;
     }
-  ]] HAVE_IPV6)
+  ]] _PHP_HAVE_IPV6)
 cmake_pop_check_state()
 
-if(HAVE_IPV6)
+if(_PHP_HAVE_IPV6)
+  set(HAVE_IPV6 TRUE)
   message(CHECK_PASS "yes")
 else()
   message(CHECK_FAIL "no")

--- a/cmake/cmake/modules/PHP/CheckInline.cmake
+++ b/cmake/cmake/modules/PHP/CheckInline.cmake
@@ -80,7 +80,7 @@ if(NOT INLINE_KEYWORD_DEFINITION)
     INLINE_KEYWORD_DEFINITION
     "${INLINE_STRING}"
     CACHE INTERNAL
-    "Compiler inline keyword definition"
+    "Compiler inline keyword definition."
   )
 
   unset(INLINE_STRING)

--- a/cmake/cmake/modules/PHP/CheckReentrantFunctions.cmake
+++ b/cmake/cmake/modules/PHP/CheckReentrantFunctions.cmake
@@ -30,8 +30,6 @@ functions on current systems and this module might be obsolete in the future.
 
   Whether `strtok_r()` is available.
 
-## Result variables
-
 * `MISSING_ASCTIME_R_DECL`
 
   Whether `asctime_r()` is not declared.
@@ -64,6 +62,10 @@ include(CMakePushCheckState)
 function(_php_check_reentrant_function symbol header)
   string(TOUPPER "${symbol}" const)
 
+  if(DEFINED PHP_HAVE_DECL_${const})
+    return()
+  endif()
+
   # Check if linker sees the function.
   check_function_exists(${symbol} HAVE_${const})
 
@@ -76,11 +78,18 @@ function(_php_check_reentrant_function symbol header)
 
   if(NOT PHP_HAVE_DECL_${const})
     message(CHECK_FAIL "missing")
-
-    set(MISSING_${const}_DECL TRUE)
+    set(isMissing TRUE)
   else()
     message(CHECK_PASS "found")
+    set(isMissing FALSE)
   endif()
+
+  set(
+    MISSING_${const}_DECL
+    ${isMissing}
+    CACHE INTERNAL
+    "Whether the ${symbol}() is not declared."
+  )
 endfunction()
 
 _php_check_reentrant_function(asctime_r time.h)

--- a/cmake/cmake/modules/PHP/CheckSysMacros.cmake
+++ b/cmake/cmake/modules/PHP/CheckSysMacros.cmake
@@ -64,6 +64,11 @@ int main(void)
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED _PHP_HAVE_SYS_MACROS_CHECKED)
+  return()
+endif()
+
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 
@@ -96,3 +101,10 @@ if(HAVE_MAKEDEV)
 else()
   message(CHECK_FAIL "not found")
 endif()
+
+set(
+  _PHP_HAVE_SYS_MACROS_CHECKED
+  TRUE
+  CACHE INTERNAL
+  "Internal marker whether 'major', 'minor' and 'makedev' have been checked."
+)

--- a/cmake/cmake/modules/PHP/CheckTimeR.cmake
+++ b/cmake/cmake/modules/PHP/CheckTimeR.cmake
@@ -17,6 +17,11 @@ POSIX.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_HPUX_TIME_R OR DEFINED PHP_IRIX_TIME_R)
+  return()
+endif()
+
 include(CheckSourceRuns)
 
 message(CHECK_START "Checking type of reentrant time-related functions")

--- a/cmake/cmake/modules/PHP/CheckWrite.cmake
+++ b/cmake/cmake/modules/PHP/CheckWrite.cmake
@@ -12,6 +12,11 @@ Check whether writing to stdout works.
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_WRITE_STDOUT)
+  return()
+endif()
+
 include(CheckIncludeFile)
 include(CheckSourceRuns)
 include(CMakePushCheckState)

--- a/cmake/cmake/modules/PHP/Extensions.cmake
+++ b/cmake/cmake/modules/PHP/Extensions.cmake
@@ -503,10 +503,11 @@ function(php_extensions_configure_headers)
       file(READ ${binaryDir}/config.h current)
     endif()
 
-    string(STRIP "${template}\n${current}" config)
-
     # Finalize extension's config.h header file.
-    file(CONFIGURE OUTPUT ${binaryDir}/config.h CONTENT "${config}\n")
+    if(NOT current MATCHES "(#undef|#define) ${macro}")
+      string(STRIP "${template}\n${current}" config)
+      file(CONFIGURE OUTPUT ${binaryDir}/config.h CONTENT "${config}\n")
+    endif()
   endforeach()
 endfunction()
 

--- a/cmake/cmake/modules/PHP/Re2c.cmake
+++ b/cmake/cmake/modules/PHP/Re2c.cmake
@@ -296,14 +296,14 @@ function(php_re2c name input output)
 
   _php_re2c_config()
 
+  # Skip consecutive find_package() calls when:
+  # - project calls php_re2c() multiple times and re2c will be downloaded
+  # - the outer find_package() was called prior to php_re2c()
+  # - running consecutive configuration phases and re2c will be downloaded
   if(
-    # Skip consecutive find_package() calls when:
-    # - project calls php_re2c() multiple times and re2c will be downloaded:
     NOT TARGET RE2C::RE2C
-    # - the outer find_package() was called prior to php_re2c():
     AND NOT DEFINED RE2C_FOUND
-    # - running consecutive configuration phases:
-    AND NOT RE2C_EXECUTABLE
+    AND NOT _PHP_RE2C_DOWNLOAD
   )
     find_package(RE2C ${PHP_RE2C_VERSION} ${quiet})
   endif()
@@ -652,6 +652,13 @@ function(_php_re2c_download)
   set_property(GLOBAL PROPERTY PACKAGES_NOT_FOUND packagesNotFound)
   get_property(packagesFound GLOBAL PROPERTY PACKAGES_FOUND)
   set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND RE2C)
+
+  set(
+    _PHP_RE2C_DOWNLOAD
+    TRUE
+    CACHE INTERNAL
+    "Internal marker whether the re2c will be downloaded."
+  )
 
   return(PROPAGATE RE2C_FOUND RE2C_VERSION)
 endfunction()

--- a/cmake/cmake/modules/PHP/SearchLibraries.cmake
+++ b/cmake/cmake/modules/PHP/SearchLibraries.cmake
@@ -325,8 +325,10 @@ function(php_search_libraries)
 
       # Store found library in a cache variable for internal purpose.
       set(
-        ${libraryInternalVariable} ${library}
-        CACHE INTERNAL "Library required to use '${symbol}'."
+        ${libraryInternalVariable}
+        ${library}
+        CACHE INTERNAL
+        "Library required to use '${symbol}'."
       )
 
       _php_search_libraries_populate()

--- a/cmake/cmake/modules/PHP/SystemExtensions.cmake
+++ b/cmake/cmake/modules/PHP/SystemExtensions.cmake
@@ -85,7 +85,11 @@ string(APPEND CMAKE_C_FLAGS " -D<extension>=1 ")`
 
 # Set configuration header code for consecutive module inclusions, if needed.
 if(NOT PHP_SYSTEM_EXTENSIONS_CODE)
-  get_property(PHP_SYSTEM_EXTENSIONS_CODE GLOBAL PROPERTY _PHP_SYSTEM_EXTENSIONS_CODE)
+  get_property(
+    PHP_SYSTEM_EXTENSIONS_CODE
+    GLOBAL
+    PROPERTY _PHP_SYSTEM_EXTENSIONS_CODE
+  )
 endif()
 
 include_guard(GLOBAL)

--- a/cmake/ext/session/cmake/CheckPreadPwrite.cmake
+++ b/cmake/ext/session/cmake/CheckPreadPwrite.cmake
@@ -34,6 +34,11 @@ check_symbol_exists(<symbol> unistd.h HAVE_<SYMBOL>)
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED _PHP_HAVE_PREAD AND DEFINED _PHP_HAVE_PWRITE)
+  return()
+endif()
+
 include(CheckFunctionExists)
 include(CheckSourceRuns)
 include(CMakePushCheckState)
@@ -49,10 +54,10 @@ function(_php_check_pread)
   # Check if linker sees the pread().
   cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_QUIET TRUE)
-    check_function_exists(pread _HAVE_PREAD)
+    check_function_exists(pread _PHP_HAVE_PREAD)
   cmake_pop_check_state()
 
-  if(NOT _HAVE_PREAD)
+  if(NOT _PHP_HAVE_PREAD)
     message(CHECK_FAIL "no (not found)")
     return()
   endif()
@@ -136,7 +141,7 @@ function(_php_check_pread)
     cmake_pop_check_state()
 
     if(PHP_PREAD_64)
-      set(HAVE_PREAD TRUE CACHE INTERNAL "Whether pread() works")
+      set(HAVE_PREAD TRUE CACHE INTERNAL "Whether pread() works.")
     endif()
   endif()
 
@@ -157,10 +162,10 @@ function(_php_check_pwrite)
   # Check if linker sees the pwrite().
   cmake_push_check_state(RESET)
     set(CMAKE_REQUIRED_QUIET TRUE)
-    check_function_exists(pwrite _HAVE_PWRITE)
+    check_function_exists(pwrite _PHP_HAVE_PWRITE)
   cmake_pop_check_state()
 
-  if(NOT _HAVE_PWRITE)
+  if(NOT _PHP_HAVE_PWRITE)
     message(CHECK_FAIL "no (not found)")
     return()
   endif()
@@ -243,7 +248,7 @@ function(_php_check_pwrite)
     cmake_pop_check_state()
 
     if(PHP_PWRITE_64)
-      set(HAVE_PWRITE TRUE CACHE INTERNAL "Whether pwrite() works")
+      set(HAVE_PWRITE TRUE CACHE INTERNAL "Whether pwrite() works.")
     endif()
   endif()
 

--- a/cmake/ext/standard/cmake/CheckCrypt.cmake
+++ b/cmake/ext/standard/cmake/CheckCrypt.cmake
@@ -133,8 +133,10 @@ function(_php_check_crypt_r result)
 
     if(CRYPT_R_GNU_SOURCE)
       set(
-        CRYPT_R_STRUCT_CRYPT_DATA TRUE
-        CACHE INTERNAL "Define if crypt_r uses struct crypt_data"
+        CRYPT_R_STRUCT_CRYPT_DATA
+        TRUE
+        CACHE INTERNAL
+        "Whether 'crypt_r()' uses 'struct crypt_data'."
       )
 
       message(CHECK_PASS "GNU struct crypt_data")
@@ -157,8 +159,10 @@ function(_php_check_crypt_r result)
 
     if(_CRYPT_R_STRUCT_CRYPT_DATA)
       set(
-        CRYPT_R_STRUCT_CRYPT_DATA TRUE
-        CACHE INTERNAL "Define if crypt_r uses struct crypt_data"
+        CRYPT_R_STRUCT_CRYPT_DATA
+        TRUE
+        CACHE INTERNAL
+        "Whether 'crypt_r()' uses 'struct crypt_data'."
       )
 
       message(CHECK_PASS "struct crypt_data")

--- a/cmake/ext/standard/cmake/CheckFclose.cmake
+++ b/cmake/ext/standard/cmake/CheckFclose.cmake
@@ -6,12 +6,15 @@ like SunOS has. This check is obsolete on current Solaris/illumos versions.
 
 ## Result variables
 
-* MISSING_FCLOSE_DECL
-
-  Whether `fclose` declaration is missing.
+* `MISSING_FCLOSE_DECL`
 #]=============================================================================]
 
 include_guard(GLOBAL)
+
+# Skip in consecutive configuration phases.
+if(DEFINED MISSING_FCLOSE_DECL)
+  return()
+endif()
 
 include(CheckSymbolExists)
 include(CMakePushCheckState)
@@ -21,12 +24,20 @@ message(CHECK_START "Checking fclose declaration")
 # Checking if symbol exists also checks if it is declared.
 cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_QUIET TRUE)
-  check_symbol_exists(fclose stdio.h _HAVE_FCLOSE)
+  check_symbol_exists(fclose stdio.h _PHP_HAVE_FCLOSE)
 cmake_pop_check_state()
 
-if(NOT _HAVE_FCLOSE)
-  message(CHECK_FAIL "missing")
-  set(MISSING_FCLOSE_DECL TRUE)
-else()
+set(
+  MISSING_FCLOSE_DECL
+  ""
+  CACHE INTERNAL
+  "Whether the 'fclose()' declaration is missing."
+)
+
+if(_PHP_HAVE_FCLOSE)
   message(CHECK_PASS "found")
+  set_property(CACHE MISSING_FCLOSE_DECL PROPERTY VALUE FALSE)
+else()
+  message(CHECK_FAIL "missing")
+  set_property(CACHE MISSING_FCLOSE_DECL PROPERTY VALUE TRUE)
 endif()

--- a/cmake/ext/standard/cmake/CheckFnmatch.cmake
+++ b/cmake/ext/standard/cmake/CheckFnmatch.cmake
@@ -19,6 +19,11 @@ https://www.gnu.org/software/gnulib/MODULES.html#module=fnmatch
 
 include_guard(GLOBAL)
 
+# Skip in consecutive configuration phases.
+if(DEFINED HAVE_FNMATCH)
+  return()
+endif()
+
 include(CheckSourceRuns)
 include(CMakePushCheckState)
 


### PR DESCRIPTION
This aims to improve running consecutive configuration phases. Very basic example:

```sh
cmake -B <build-dir>
cmake -B <build-dir>
```

The 2nd configuration phase should be lightning fast and without too much redundant output in the configure log - following behavior of existing CMake modules.