### PR TITLE
Improve build-defs.h configuration

### DIFF
--- a/cmake/Zend/CMakeLists.txt
+++ b/cmake/Zend/CMakeLists.txt
@@ -578,7 +578,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   file(
     CONFIGURE
     OUTPUT zend_config.h
-    CONTENT "#include <../main/php_config.h>\n"
+    CONTENT "#include <php_config.h>\n"
   )
 endif()
 

--- a/cmake/cmake/modules/FindGcov.cmake
+++ b/cmake/cmake/modules/FindGcov.cmake
@@ -149,7 +149,7 @@ macro(gcov_generate_report)
       message(STATUS \"Generating gcovr HTML\")
       # Clean generated gcovr_html directory. Checks are done as safeguards.
       if(
-        EXISTS ${PROJECT_BINARY_DIR}/main/php_config.h
+        EXISTS ${PROJECT_BINARY_DIR}/main/internal_functions.c
         AND EXISTS ${PROJECT_BINARY_DIR}/gcovr_html
       )
         file(REMOVE_RECURSE ${PROJECT_BINARY_DIR}/gcovr_html)
@@ -173,7 +173,7 @@ macro(gcov_generate_report)
       message(STATUS \"Generating gcovr XML\")
       # Clean generated gcovr.xml file. Checks are done as safeguards.
       if(
-        EXISTS ${PROJECT_BINARY_DIR}/main/php_config.h
+        EXISTS ${PROJECT_BINARY_DIR}/main/internal_functions.c
         AND EXISTS ${PROJECT_BINARY_DIR}/gcovr.xml
       )
         file(REMOVE ${PROJECT_BINARY_DIR}/gcovr.xml)

--- a/cmake/cmake/modules/FindSendmail.cmake
+++ b/cmake/cmake/modules/FindSendmail.cmake
@@ -9,8 +9,9 @@ either `sendmail` is used if found, or a general default value is set to
 ## Result variables
 
 * `Sendmail_FOUND` - Whether sendmail has been found.
-* `PROG_SENDMAIL` - Path to the sendmail executable program, either found by
-  the module or set to a sensible default value.
+* `Sendmail_PROGRAM` - Path to the sendmail executable program, either found by
+  the module or set to a sensible default value for usage in PHP. On Windows,
+  this is set to an empty string as PHP uses a built in mailer there.
 
 ## Cache variables
 
@@ -39,6 +40,7 @@ set(_reason "")
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(_sendmailIsBuiltInMsg "PHP built-in mailer (Windows)")
   set(_sendmailRequiredVars _sendmailIsBuiltInMsg)
+  set(Sendmail_PROGRAM "")
 else()
   find_program(
     Sendmail_EXECUTABLE
@@ -50,14 +52,14 @@ else()
   set(_sendmailRequiredVars Sendmail_EXECUTABLE)
 
   if(Sendmail_EXECUTABLE)
-    set(PROG_SENDMAIL ${Sendmail_EXECUTABLE})
+    set(Sendmail_PROGRAM "${Sendmail_EXECUTABLE}")
   else()
-    set(PROG_SENDMAIL "/usr/sbin/sendmail")
+    set(Sendmail_PROGRAM "/usr/sbin/sendmail")
   endif()
 
   set(
     _reason
-    "sendmail not found. Default set to ${PROG_SENDMAIL}.
+    "sendmail not found. Default set to ${Sendmail_PROGRAM}.
     It can be overridden with 'sendmail_path' php.ini directive."
   )
 endif()

--- a/cmake/ext/odbc/CMakeLists.txt
+++ b/cmake/ext/odbc/CMakeLists.txt
@@ -273,11 +273,6 @@ if(PHP_EXT_ODBC_VERSION AND NOT PHP_EXT_ODBC_VERSION MATCHES "^0x[0-9A-Fa-f]+$")
   )
 endif()
 
-unset(PHP_ODBC_CFLAGS CACHE)
-unset(PHP_ODBC_LFLAGS CACHE)
-unset(PHP_ODBC_LIBS CACHE)
-unset(PHP_ODBC_TYPE CACHE)
-
 if(NOT PHP_EXT_ODBC)
   return()
 endif()
@@ -332,7 +327,7 @@ if(PHP_EXT_ODBC_TYPE STREQUAL "ibm-db2" AND TARGET ODBC::ODBC)
 endif()
 
 ################################################################################
-# Set variables for main/build-defs.h and config.h file.
+# Configure config.h file.
 ################################################################################
 
 # Set PHP_ODBC_TYPE for configuration header value.
@@ -394,7 +389,7 @@ if(NOT PHP_EXT_ODBC_TYPE MATCHES "^(dbmaker|solid)$")
   set(HAVE_SQLDATASOURCES TRUE)
 endif()
 
-if(TARGET ODBC::ODBC)
+if(TARGET ODBC::ODBC AND NOT ODBC_DRIVER STREQUAL "Windows")
   block(PROPAGATE PHP_ODBC_BUILD_DEFINITIONS_CODE)
     get_target_property(definitions ODBC::ODBC INTERFACE_COMPILE_DEFINITIONS)
     get_target_property(options ODBC::ODBC INTERFACE_COMPILE_OPTIONS)
@@ -430,37 +425,18 @@ if(TARGET ODBC::ODBC)
     list(JOIN ldflags " " ldflags)
     list(JOIN libs " " libs)
 
-    set(PHP_ODBC_CFLAGS "${cflags}" CACHE INTERNAL "ODBC CFLAGS")
-    set(PHP_ODBC_LFLAGS "${ldflags}" CACHE INTERNAL "ODBC linker flags")
-    set(PHP_ODBC_LIBS "${libs}" CACHE INTERNAL "ODBC libraries")
-    set(PHP_ODBC_TYPE "${PHP_ODBC_TYPE}" CACHE INTERNAL "ODBC type")
-
-    if(
-      NOT ODBC_DRIVER STREQUAL "Windows"
-      AND NOT EXISTS ${PHP_SOURCE_DIR}/main/build-defs.h.in
-    )
-      set(
-        PHP_ODBC_BUILD_DEFINITIONS_CODE
-        [[
+    string(CONFIGURE [[
 /* The compile options that PHP odbc extension was built with. */
-#define PHP_ODBC_CFLAGS "@PHP_ODBC_CFLAGS@"
+#define PHP_ODBC_CFLAGS "@cflags@"
 
 /* The linker flags that PHP odbc extension was built with. */
-#define PHP_ODBC_LFLAGS "@PHP_ODBC_LFLAGS@"
+#define PHP_ODBC_LFLAGS "@ldflags@"
 
 /* The libraries linker flags that PHP odbc extension was built with. */
-#define PHP_ODBC_LIBS "@PHP_ODBC_LIBS@"
+#define PHP_ODBC_LIBS "@libs@"
 
 /* The ODBC library used in the PHP odbc extension. */
-#define PHP_ODBC_TYPE "@PHP_ODBC_TYPE@"]]
-      )
-
-      string(
-        CONFIGURE
-        "${PHP_ODBC_BUILD_DEFINITIONS_CODE}"
-        PHP_ODBC_BUILD_DEFINITIONS_CODE
-      )
-    endif()
+#define PHP_ODBC_TYPE "@PHP_ODBC_TYPE@"]] PHP_ODBC_BUILD_DEFINITIONS_CODE)
   endblock()
 endif()
 

--- a/cmake/main/CMakeLists.txt
+++ b/cmake/main/CMakeLists.txt
@@ -94,11 +94,11 @@ target_sources(
   PUBLIC
     FILE_SET generated
       TYPE HEADERS
-      BASE_DIRS ${CMAKE_CURRENT_BINARY_DIR}
+      BASE_DIRS ${PHP_BINARY_DIR}/$<CONFIG>/main
       FILES
-        $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_BINARY_DIR}/config.w32.h>
-        $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_BINARY_DIR}/build-defs.h>
-        $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_BINARY_DIR}/php_config.h>
+        $<$<PLATFORM_ID:Windows>:${PHP_BINARY_DIR}/$<CONFIG>/main/config.w32.h>
+        ${PHP_BINARY_DIR}/$<CONFIG>/main/build-defs.h
+        $<$<NOT:$<PLATFORM_ID:Windows>>:${PHP_BINARY_DIR}/$<CONFIG>/main/php_config.h>
 )
 
 ################################################################################
@@ -115,6 +115,8 @@ target_include_directories(
   php_config
   INTERFACE
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${PHP_BINARY_DIR}/$<CONFIG>
+    ${PHP_BINARY_DIR}/$<CONFIG>/main
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -228,82 +230,96 @@ file(CONFIGURE OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/php_version.h CONTENT [[
 # Generate configuration headers.
 ################################################################################
 
-# Run at the end of the configuration.
-cmake_language(DEFER DIRECTORY ${PHP_SOURCE_DIR} CALL _php_main_create_files)
-function(_php_main_create_files)
-  ##############################################################################
-  # Map CMake variable names to names in PHP configuration headers where needed.
-  ##############################################################################
+# Configure build system configuration header (build-defs.h).
+function(_php_main_configure_build_defs)
+  message(STATUS "Configuring build-defs.h")
 
-  # TODO: Set configure command string.
-  set(CONFIGURE_COMMAND "cmake")
+  string(CONFIGURE [[
+    set(CONFIGURE_COMMAND "cmake")
 
-  # TODO: Fix the installation prefixes below when passed via the '--prefix'
-  # option of the 'cmake --install ...' command. PHP is at the time of writing
-  # not a relocatable program.
+    if(NOT "@PHP_PEAR_DIR@" STREQUAL "")
+      set(PEAR_INSTALLDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@PHP_PEAR_DIR@,${CMAKE_INSTALL_PREFIX}>")
+    endif()
 
-  if(PHP_PEAR_DIR)
-    set(
-      EXPANDED_PEAR_INSTALLDIR
-      "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_PEAR_DIR},${CMAKE_INSTALL_PREFIX}>"
+    set(PHP_BINDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_BINDIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    if("@CMAKE_SYSTEM_NAME@" STREQUAL "Windows")
+      set(EXPANDED_PHP_CONFIG_FILE_PATH "")
+    else()
+      set(EXPANDED_PHP_CONFIG_FILE_PATH "$<PATH:ABSOLUTE_PATH,NORMALIZE,@PHP_CONFIG_FILE_PATH@,${CMAKE_INSTALL_PREFIX}>")
+    endif()
+
+    set(EXPANDED_PHP_CONFIG_FILE_SCAN_DIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@PHP_CONFIG_FILE_SCAN_DIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    set(PHP_DATADIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_DATADIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    set(EXPANDED_EXTENSION_DIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@PHP_EXTENSION_DIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    if("@CMAKE_SYSTEM_NAME@" STREQUAL "Windows")
+      set(PHP_INCLUDE_PATH ".;${PEAR_INSTALLDIR}")
+    else()
+      set(PHP_INCLUDE_PATH ".:${PEAR_INSTALLDIR}")
+    endif()
+
+    set(PHP_LIBDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_LIBDIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    set(PHP_LOCALSTATEDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_LOCALSTATEDIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    if("@CMAKE_SYSTEM_NAME@" STREQUAL "Windows")
+      set(PHP_MANDIR "")
+    else()
+      set(PHP_MANDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_MANDIR@,${CMAKE_INSTALL_PREFIX}>")
+    endif()
+
+    set(PHP_PROG_SENDMAIL "@Sendmail_PROGRAM@")
+
+    set(PHP_SBINDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_SBINDIR@,${CMAKE_INSTALL_PREFIX}>")
+
+    if("@CMAKE_SYSTEM_NAME@" STREQUAL "Windows")
+      set(PHP_SHLIB_EXT_PREFIX "php_")
+    else()
+      set(PHP_SHLIB_EXT_PREFIX "")
+    endif()
+
+    string(REPLACE "." "" PHP_SHLIB_SUFFIX "@CMAKE_SHARED_MODULE_SUFFIX@")
+
+    set(PHP_SYSCONFDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_SYSCONFDIR@,${CMAKE_INSTALL_PREFIX}>")
+  ]] code @ONLY)
+  cmake_language(EVAL CODE "${code}")
+
+  file(READ main/cmake/build-defs.h.in content)
+  string(CONFIGURE "${content}" content @ONLY)
+  file(
+    GENERATE
+    OUTPUT ${PHP_BINARY_DIR}/$<CONFIG>/main/build-defs.h
+    CONTENT "${content}"
+  )
+
+  # Regenerate file on the install step when using different installation
+  # prefix at the 'cmake --install ... --prefix <install-prefix>' phase.
+  string(CONFIGURE [[
+    @code@
+    configure_file(
+      "@PHP_SOURCE_DIR@/main/cmake/build-defs.h.in"
+      "@PHP_BINARY_DIR@/$<CONFIG>/main/build-defs.h"
+      @ONLY
     )
+  ]] code @ONLY)
+  install(CODE "${code}")
+endfunction()
+
+# Configure main configuration header (php_config.h, config.w32.h).
+function(_php_main_configure_php_config)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(PHP_CONFIG_H_WINDOWS 1)
+    set(file config.w32.h)
+  else()
+    set(PHP_CONFIG_H_WINDOWS 0)
+    set(file php_config.h)
+    set(HAVE_BUILD_DEFS_H TRUE)
   endif()
 
-  # Set the 'include_path' INI directive.
-  set(
-    INCLUDE_PATH
-    ".$<IF:$<PLATFORM_ID:Windows>,;,:>${EXPANDED_PEAR_INSTALLDIR}"
-  )
-
-  # Set the PHP extensions directory.
-  set(
-    EXPANDED_EXTENSION_DIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_EXTENSION_DIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  # Set the directory where php.ini is looked for.
-  set(
-    EXPANDED_PHP_CONFIG_FILE_PATH
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_CONFIG_FILE_PATH},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  # Set the directory where additional ini files are searched for.
-  set(
-    EXPANDED_PHP_CONFIG_FILE_SCAN_DIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_CONFIG_FILE_SCAN_DIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(
-    EXPANDED_BINDIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_BINDIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(
-    EXPANDED_SBINDIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_SBINDIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(
-    EXPANDED_MANDIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_MANDIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(
-    EXPANDED_LIBDIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_LIBDIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(
-    EXPANDED_DATADIR
-    "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_DATADIR},${CMAKE_INSTALL_PREFIX}>"
-  )
-
-  set(EXPANDED_SYSCONFDIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}")
-  set(EXPANDED_LOCALSTATEDIR "${CMAKE_INSTALL_FULL_LOCALSTATEDIR}")
-  set(prefix "${CMAKE_INSTALL_PREFIX}")
-
-  # Set shared library object extension.
-  string(REPLACE "." "" SHLIB_DL_SUFFIX_NAME ${CMAKE_SHARED_MODULE_SUFFIX})
+  message(STATUS "Configuring ${file}")
 
   if(PHP_DEFAULT_SHORT_OPEN_TAG)
     set(DEFAULT_SHORT_OPEN_TAG "1")
@@ -311,7 +327,7 @@ function(_php_main_create_files)
     set(DEFAULT_SHORT_OPEN_TAG "0")
   endif()
 
-  # Add sapis configuration.
+  # Add SAPIs configuration.
   set(config "")
   get_property(sapis GLOBAL PROPERTY PHP_SAPIS)
   list(SORT sapis COMPARE NATURAL)
@@ -343,88 +359,27 @@ function(_php_main_create_files)
   file(READ ${CMAKE_CURRENT_BINARY_DIR}/Zend/CMakeFiles/zend_config.h config)
   string(STRIP "${config}" ZEND_CONFIGURATION)
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(PHP_CONFIG_H_WINDOWS 1)
-    set(file config.w32.h)
-  else()
-    set(ODBC_CFLAGS "${PHP_ODBC_CFLAGS}")
-    set(ODBC_LFLAGS "${PHP_ODBC_LFLAGS}")
-    set(ODBC_LIBS "${PHP_ODBC_LIBS}")
-    set(ODBC_TYPE "${PHP_ODBC_TYPE}")
-    message(STATUS "Creating main/build-defs.h")
-    file(READ main/build-defs.h.in content)
-    string(CONFIGURE "${content}" content @ONLY)
-
-    # To be able to evaluate the generator expressions.
-    file(
-      GENERATE
-      # TODO: Multi-config generators need to write separate files.
-      #OUTPUT $<CONFIG>/main/build-defs.h
-      OUTPUT main/build-defs.h
-      CONTENT "${content}"
-    )
-
-    #[[
-    TODO: This enables regenerating the build-defs.h file on the install step
-    when using different install prefix at the 'cmake --install ... --prefix'
-    phase. Needs to be adjusted further to rebuild PHP at such case.
-    include(PHP/ConfigureFile)
-    php_configure_file(
-      INPUT ${PHP_SOURCE_DIR}/main/build-defs.h.in
-      OUTPUT ${PHP_BINARY_DIR}/main/build-defs.h
-      VARIABLES
-        CONFIGURE_COMMAND "cmake"
-        ODBC_CFLAGS "${PHP_ODBC_CFLAGS}"
-        ODBC_LFLAGS "${PHP_ODBC_LFLAGS}"
-        ODBC_LIBS "${PHP_ODBC_LIBS}"
-        ODBC_TYPE "${PHP_ODBC_TYPE}"
-        PROG_SENDMAIL "${PROG_SENDMAIL}"
-        EXPANDED_PEAR_INSTALLDIR "${EXPANDED_PEAR_INSTALLDIR}"
-        INCLUDE_PATH "${INCLUDE_PATH}"
-        EXPANDED_EXTENSION_DIR "${EXPANDED_EXTENSION_DIR}"
-        prefix "$<INSTALL_PREFIX>"
-        EXPANDED_BINDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_BINDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_SBINDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_SBINDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_MANDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_MANDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_LIBDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_LIBDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_DATADIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_DATADIR},$<INSTALL_PREFIX>>"
-        EXPANDED_SYSCONFDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_SYSCONFDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_LOCALSTATEDIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_LOCALSTATEDIR},$<INSTALL_PREFIX>>"
-        EXPANDED_PHP_CONFIG_FILE_PATH "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_CONFIG_FILE_PATH},$<INSTALL_PREFIX>>"
-        EXPANDED_PHP_CONFIG_FILE_SCAN_DIR "$<PATH:ABSOLUTE_PATH,NORMALIZE,${PHP_CONFIG_FILE_SCAN_DIR},$<INSTALL_PREFIX>>"
-        SHLIB_DL_SUFFIX_NAME "${SHLIB_DL_SUFFIX_NAME}"
-    )
-    add_custom_target(php_main_build_defs_h DEPENDS ${PHP_BINARY_DIR}/main/build-defs.h)
-    add_dependencies(php_main php_main_build_defs_h)
-    #]]
-
-    set(HAVE_BUILD_DEFS_H TRUE)
-    set(PHP_CONFIG_H_WINDOWS 0)
-    set(file php_config.h)
-  endif()
-
-  message(STATUS "Creating main/${file}")
   file(READ main/cmake/php_config.h.in content)
   string(CONFIGURE "${content}" content @ONLY)
-
   file(
     GENERATE
-    # TODO: Multi-config generators need to write separate files.
-    #OUTPUT $<CONFIG>/main/${file}
-    OUTPUT main/${file}
+    OUTPUT ${PHP_BINARY_DIR}/$<CONFIG>/main/${file}
     CONTENT "${content}"
   )
 endfunction()
 
-################################################################################
-# Configure installation.
-################################################################################
+# Run at the end of the configuration - configure headers and installation.
+cmake_language(DEFER DIRECTORY ${PHP_SOURCE_DIR} CALL _php_main_create_files)
+function(_php_main_create_files)
+  _php_main_configure_build_defs()
+  _php_main_configure_php_config()
 
-install(
-  TARGETS php_main
-  ARCHIVE EXCLUDE_FROM_ALL
-  FILE_SET HEADERS
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX}/main
-  FILE_SET generated
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX}/main
-)
+  install(
+    TARGETS php_main
+    ARCHIVE EXCLUDE_FROM_ALL
+    FILE_SET HEADERS
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX}/main
+    FILE_SET generated
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX}/main
+  )
+endfunction()

--- a/cmake/main/cmake/build-defs.h.in
+++ b/cmake/main/cmake/build-defs.h.in
@@ -1,0 +1,66 @@
+/* The following build system related configuration is in Autotools build system
+   defined in the main/build-defs.h header and in JScript Windows build system
+   in the main/config.w32.h header. These are provided as a separate header file
+   aiming to simplify the re-build phase when multiple configurations are used.
+   For example, using different installation prefixes for the stage and
+   production installation directories. */
+
+#ifndef _PHP_BUILD_DEFS_H
+#define _PHP_BUILD_DEFS_H
+
+/* Command used for configuring PHP at build phase. */
+#cmakedefine CONFIGURE_COMMAND "@CONFIGURE_COMMAND@"
+
+/* The path to the PEAR installation directory. */
+#define PEAR_INSTALLDIR "@PEAR_INSTALLDIR@"
+
+/* The path to the directory containing command-line executables (bin). */
+#define PHP_BINDIR "@PHP_BINDIR@"
+
+/* The path to the directory in which PHP looks for the php.ini configuration
+   file. On Windows this macro isn't utilized in the C code. */
+#define PHP_CONFIG_FILE_PATH "@EXPANDED_PHP_CONFIG_FILE_PATH@"
+
+/* The path to the directory where PHP scans for additional INI
+   configuration files. */
+#define PHP_CONFIG_FILE_SCAN_DIR "@EXPANDED_PHP_CONFIG_FILE_SCAN_DIR@"
+
+/* The path to the directory containing architecture-independent data
+   (share). */
+#define PHP_DATADIR "@PHP_DATADIR@"
+
+/* The default path to the directory containing dynamically loadable PHP
+   extensions. */
+#define PHP_EXTENSION_DIR "@EXPANDED_EXTENSION_DIR@"
+
+/* The default 'include_path' PHP INI directive. */
+#define PHP_INCLUDE_PATH "@PHP_INCLUDE_PATH@"
+
+/* The path to the directory containing system libraries (lib). */
+#define PHP_LIBDIR "@PHP_LIBDIR@"
+
+/* The path to the directory containing modifiable single-machine data (var). */
+#define PHP_LOCALSTATEDIR "@PHP_LOCALSTATEDIR@"
+
+/* The path to the directory containing man documentation. */
+#cmakedefine PHP_MANDIR "@PHP_MANDIR@"
+
+/* The PHP installation prefix. */
+#define PHP_PREFIX "@CMAKE_INSTALL_PREFIX@"
+
+/* The path to the sendmail program. PHP on Windows uses a built in mailer. */
+#cmakedefine PHP_PROG_SENDMAIL "@PHP_PROG_SENDMAIL@"
+
+/* The path to the directory containing system admin executables (sbin). */
+#define PHP_SBINDIR "@PHP_SBINDIR@"
+
+/* The filename prefix for the shared PHP extensions. */
+#define PHP_SHLIB_EXT_PREFIX "@PHP_SHLIB_EXT_PREFIX@"
+
+/* The file extension of the shared PHP extensions ('so', 'dll'). */
+#define PHP_SHLIB_SUFFIX "@PHP_SHLIB_SUFFIX@"
+
+/* The path to the directory containing read-only single-machine data (etc). */
+#define PHP_SYSCONFDIR "@PHP_SYSCONFDIR@"
+
+#endif

--- a/cmake/main/cmake/php_config.h.in
+++ b/cmake/main/cmake/php_config.h.in
@@ -672,12 +672,8 @@
 /* Define if processor uses big-endian word. */
 #cmakedefine WORDS_BIGENDIAN
 
-/* Define to 1 if debugging is enabled, and to 0 if not.
-   TODO: This is still not good enough because multi-config generators would
-   then need separate php_config.h files for each build type. */
-#ifndef ZEND_DEBUG
-# define ZEND_DEBUG $<IF:$<CONFIG:Debug,DebugAssertions>,1,0>
-#endif
+/* Define to 1 if PHP debugging is enabled, and to 0 if not. */
+#define ZEND_DEBUG $<IF:$<CONFIG:Debug,DebugAssertions>,1,0>
 
 /* Define to 1 if thread safety (ZTS) is enabled. */
 #cmakedefine ZTS 1
@@ -704,53 +700,7 @@
 @ZEND_CONFIGURATION@
 
 #if @PHP_CONFIG_H_WINDOWS@
-/* The following build system related configuration values are on *nix
-   systems defined in the main/build-defs.h and JScript Windows build system
-   defines them in the configuration header file. */
-
-/* Configure line */
-# cmakedefine CONFIGURE_COMMAND "@CONFIGURE_COMMAND@"
-
-/* The PEAR installation directory. */
-# define PEAR_INSTALLDIR "@EXPANDED_PEAR_INSTALLDIR@"
-
-/* The path to the bin directory. */
-# define PHP_BINDIR "@EXPANDED_BINDIR@"
-
-/* The path in which to look for php.ini. On Windows this macro isn't
-   utilized in the C code. */
-# define PHP_CONFIG_FILE_PATH ""
-
-/* The path where to scan for additional INI configuration files. */
-# define PHP_CONFIG_FILE_SCAN_DIR "@EXPANDED_PHP_CONFIG_FILE_SCAN_DIR@"
-
-/* The path to the share directory. */
-# define PHP_DATADIR "@EXPANDED_DATADIR@"
-
-/* Default directory for dynamically loadable PHP extensions. */
-# define PHP_EXTENSION_DIR "@EXPANDED_EXTENSION_DIR@"
-
-/* The 'include_path' PHP INI directive. */
-# define PHP_INCLUDE_PATH "@INCLUDE_PATH@"
-
-/* The path containing system libraries (lib or lib64). */
-# define PHP_LIBDIR "@EXPANDED_LIBDIR@"
-
-/* The path to the var directory. */
-# define PHP_LOCALSTATEDIR "@EXPANDED_LOCALSTATEDIR@"
-
-/* The installation prefix. */
-# define PHP_PREFIX "@prefix@"
-
-/* The prefix for the shared library objects. */
-# define PHP_SHLIB_EXT_PREFIX "php_"
-
-/* The shared library objects extension. */
-# define PHP_SHLIB_SUFFIX "@SHLIB_DL_SUFFIX_NAME@"
-
-/* The path to the etc directory. */
-# define PHP_SYSCONFDIR "@EXPANDED_SYSCONFDIR@"
-
+# include "build-defs.h"
 # if __has_include("main/config.pickle.h")
 #  include "main/config.pickle.h"
 # endif

--- a/cmake/scripts/CMakeLists.txt
+++ b/cmake/scripts/CMakeLists.txt
@@ -38,7 +38,9 @@ block()
     set(SED /usr/bin/sed)
   endif()
 
+  ##############################################################################
   message(STATUS "Creating scripts/php-config")
+  ##############################################################################
 
   get_property(sapis GLOBAL PROPERTY PHP_SAPIS)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
@@ -60,7 +62,7 @@ block()
 
   php_configure_file(
     CONTENT "${content}"
-    OUTPUT php-config
+    OUTPUT ${PHP_BINARY_DIR}/$<CONFIG>/scripts/php-config
     VARIABLES
       SED "${SED}"
       prefix "$<INSTALL_PREFIX>"
@@ -88,15 +90,17 @@ block()
 
   install(
     PROGRAMS
-    ${CMAKE_CURRENT_BINARY_DIR}/php-config
+    ${PHP_BINARY_DIR}/$<CONFIG>/scripts/php-config
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     RENAME ${PHP_PROGRAM_PREFIX}php-config${PHP_PROGRAM_SUFFIX}
   )
 
+  ##############################################################################
   message(STATUS "Creating scripts/phpize")
+  ##############################################################################
 
-  # Replace the upstream phpize script hardcoded php include directory to a
-  # template placeholder.
+  # Patch phpize template: Replace the upstream phpize script hardcoded php
+  # include directory to a template placeholder.
   file(READ "${CMAKE_CURRENT_SOURCE_DIR}/phpize.in" content)
   string(
     REPLACE
@@ -105,18 +109,32 @@ block()
     content
     "${content}"
   )
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PHP/phpize.in" "${content}")
 
-  php_configure_file(
-    CONTENT "${content}"
-    OUTPUT phpize
-    VARIABLES
-      prefix "$<INSTALL_PREFIX>"
-      datarootdir "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_DATAROOTDIR},$<INSTALL_PREFIX>>"
-      exec_prefix "$<INSTALL_PREFIX>"
-      libdir "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_LIBDIR}/php,$<INSTALL_PREFIX>>"
-      includedir "$<PATH:ABSOLUTE_PATH,NORMALIZE,${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX},$<INSTALL_PREFIX>>"
-      SED "${SED}"
-  )
+  string(CONFIGURE [[
+    set(prefix "${CMAKE_INSTALL_PREFIX}")
+    set(datarootdir "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_DATAROOTDIR@,${CMAKE_INSTALL_PREFIX}>")
+    set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
+    set(libdir "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_LIBDIR@/php,${CMAKE_INSTALL_PREFIX}>")
+    set(includedir "$<PATH:ABSOLUTE_PATH,NORMALIZE,@CMAKE_INSTALL_INCLUDEDIR@/@PHP_INCLUDE_PREFIX@,${CMAKE_INSTALL_PREFIX}>")
+    set(SED "@SED@")
+  ]] code @ONLY)
+  cmake_language(EVAL CODE "${code}")
+  string(CONFIGURE "${content}" content @ONLY)
+  file(GENERATE OUTPUT phpize CONTENT "${content}")
+
+  # This regenerates the phpize file on the install step when using
+  # different install prefix at the install phase:
+  #   'cmake --install <build-dir> --prefix <prefix>'
+  string(CONFIGURE [[
+    @code@
+    configure_file(
+      "@CMAKE_CURRENT_BINARY_DIR@/CMakeFiles/PHP/phpize.in"
+      "@CMAKE_CURRENT_BINARY_DIR@/phpize"
+      @ONLY
+    )
+  ]] code @ONLY)
+  install(CODE "${code}")
 
   install(
     PROGRAMS


### PR DESCRIPTION
This adds a CMake-related template for generating the `main/build-defs.h` header.

The ODBC build configuration is moved to its own config.h (or php_config.h) header.