### PR TITLE
Refactor pread, pwrite and ttyname_r checks

### DIFF
--- a/cmake/cmake/toolchains/template.cmake
+++ b/cmake/cmake/toolchains/template.cmake
@@ -55,10 +55,10 @@ set(ZEND_MM_EXITCODE__TRYRUN_OUTPUT "(size_t)8 (size_t)3 0")
 ################################################################################
 
 # Set the exit code for the clock_get_time() check.
-set(HAVE_CLOCK_GET_TIME_EXITCODE 0)
+set(PHP_SAPI_FPM_HAS_CLOCK_GET_TIME_EXITCODE 0)
 
-# Set the exit code of the ptrace check for PHP FPM.
-set(HAVE_PTRACE_EXITCODE 0)
+# Set the exit code of the ptrace() check.
+set(PHP_SAPI_FPM_HAS_PTRACE_EXITCODE 0)
 
 # Set the process memory access file - 'mem' on Linux-alike or 'as' on
 # Solaris-alike target systems for the PHP FPM to use pread trace type.
@@ -119,23 +119,12 @@ set(PHP_EXT_OPCACHE_HAS_SHM_MMAP_POSIX_EXITCODE 0)
 set(PHP_EXT_PCRE_HAS_JIT_EXITCODE 0)
 
 ################################################################################
-# ext/posix
-################################################################################
-
-# Set the exit code of the ttyname_r check.
-set(HAVE_TTYNAME_R_EXITCODE 0)
-
-################################################################################
 # ext/session
 ################################################################################
 
-# Set the exit code of the pread check.
-set(HAVE_PREAD_EXITCODE 0)
-set(PHP_PREAD_64_EXITCODE 0)
-
-# Set the exit code of the pwrite check.
-set(HAVE_PWRITE_EXITCODE 0)
-set(PHP_PWRITE_64_EXITCODE 0)
+# Set the exit codes for the pread()/pwrite() checks.
+set(PHP_EXT_SESSION_HAS_PREAD_EXITCODE 0)
+set(PHP_EXT_SESSION_HAS_PWRITE_EXITCODE 0)
 
 ################################################################################
 # ext/standard

--- a/cmake/sapi/fpm/CMakeLists.txt
+++ b/cmake/sapi/fpm/CMakeLists.txt
@@ -88,8 +88,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 include(CheckIncludeFiles)
-include(CheckSourceCompiles)
-include(CheckSourceRuns)
 include(CheckSymbolExists)
 include(CMakePushCheckState)
 include(FeatureSummary)
@@ -258,8 +256,13 @@ check_symbol_exists(setproctitle_fast unistd.h HAVE_SETPROCTITLE_FAST)
 check_symbol_exists(sysconf unistd.h HAVE_SYSCONF)
 check_symbol_exists(times sys/times.h HAVE_TIMES)
 
-# Check FPM listening queue implementation.
+include(cmake/CheckClockGetTime.cmake)
+include(cmake/CheckCompilerAtomicBuiltins.cmake)
+include(cmake/CheckDevPoll.cmake)
+include(cmake/CheckEpoll.cmake)
+include(cmake/CheckKqueue.cmake)
 include(cmake/CheckListeningQueue.cmake)
+include(cmake/CheckSelect.cmake)
 
 # Check FPM trace implementation.
 include(cmake/CheckTrace.cmake)
@@ -272,186 +275,6 @@ if(HAVE_PTRACE OR HAVE_MACH_VM_READ OR PROC_MEM_FILE)
   elseif(PROC_MEM_FILE)
     target_sources(php_sapi_fpm PRIVATE fpm/fpm_trace_pread.c)
   endif()
-endif()
-
-# Check for clock_get*time.
-php_search_libraries(
-  clock_gettime
-  HEADERS time.h
-  LIBRARIES
-    rt # Solaris 10
-  VARIABLE HAVE_CLOCK_GETTIME
-  TARGET php_sapi_fpm PRIVATE
-)
-if(NOT HAVE_CLOCK_GETTIME)
-  check_source_runs(C [[
-    #include <mach/mach.h>
-    #include <mach/clock.h>
-    #include <mach/mach_error.h>
-
-    int main(void)
-    {
-      kern_return_t ret;
-      clock_serv_t aClock;
-      mach_timespec_t aTime;
-
-      ret = host_get_clock_service(mach_host_self(), REALTIME_CLOCK, &aClock);
-      if (ret != KERN_SUCCESS) {
-        return 1;
-      }
-
-      ret = clock_get_time(aClock, &aTime);
-      if (ret != KERN_SUCCESS) {
-        return 2;
-      }
-
-      return 0;
-    }
-  ]] HAVE_CLOCK_GET_TIME)
-endif()
-
-# Check for compiler atomic builtins.
-message(CHECK_START "Checking if compiler has __sync_bool_compare_and_swap")
-check_source_compiles(C [[
-  int main(void)
-  {
-    int variable = 1;
-    return (__sync_bool_compare_and_swap(&variable, 1, 2)
-           && __sync_add_and_fetch(&variable, 1)) ? 1 : 0;
-  }
-]] HAVE_BUILTIN_ATOMIC)
-if(HAVE_BUILTIN_ATOMIC)
-  message(CHECK_PASS "yes")
-else()
-  message(CHECK_FAIL "no")
-endif()
-
-message(CHECK_START "Checking for kqueue")
-cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_QUIET TRUE)
-  check_source_compiles(C [[
-    #include <sys/types.h>
-    #include <sys/event.h>
-    #include <sys/time.h>
-
-    int main(void)
-    {
-      int kfd;
-      struct kevent k;
-      kfd = kqueue();
-      /* 0 -> STDIN_FILENO */
-      EV_SET(&k, 0, EVFILT_READ , EV_ADD | EV_CLEAR, 0, 0, NULL);
-      (void)kfd;
-
-      return 0;
-    }
-  ]] HAVE_KQUEUE)
-cmake_pop_check_state()
-if(HAVE_KQUEUE)
-  message(CHECK_PASS "yes")
-else()
-  message(CHECK_FAIL "no")
-endif()
-
-# For Solaris < 10.
-message(CHECK_START "Checking for /dev/poll")
-cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_QUIET TRUE)
-  check_source_compiles(C [[
-    #include <stdio.h>
-    #include <sys/devpoll.h>
-
-    int main(void)
-    {
-      int n, dp;
-      struct dvpoll dvp;
-      dp = 0;
-      dvp.dp_fds = NULL;
-      dvp.dp_nfds = 0;
-      dvp.dp_timeout = 0;
-      n = ioctl(dp, DP_POLL, &dvp);
-      (void)n;
-
-      return 0;
-    }
-  ]] HAVE_DEVPOLL)
-cmake_pop_check_state()
-if(HAVE_DEVPOLL)
-  message(CHECK_PASS "yes")
-else()
-  message(CHECK_FAIL "no")
-endif()
-
-message(CHECK_START "Checking for epoll")
-cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_QUIET TRUE)
-  check_source_compiles(C [[
-    #include <sys/epoll.h>
-
-    int main(void)
-    {
-      int epollfd;
-      struct epoll_event e;
-
-      epollfd = epoll_create(1);
-      if (epollfd < 0) {
-        return 1;
-      }
-
-      e.events = EPOLLIN | EPOLLET;
-      e.data.fd = 0;
-
-      if (epoll_ctl(epollfd, EPOLL_CTL_ADD, 0, &e) == -1) {
-        return 1;
-      }
-
-      e.events = 0;
-      if (epoll_wait(epollfd, &e, 1, 1) < 0) {
-        return 1;
-      }
-
-      return 0;
-    }
-  ]] HAVE_EPOLL)
-cmake_pop_check_state()
-if(HAVE_EPOLL)
-  message(CHECK_PASS "yes")
-else()
-  message(CHECK_FAIL "no")
-endif()
-
-message(CHECK_START "Checking for select")
-cmake_push_check_state(RESET)
-  set(CMAKE_REQUIRED_QUIET TRUE)
-
-  check_source_compiles(C [[
-    /* According to POSIX.1-2001 */
-    #include <sys/select.h>
-
-    /* According to earlier standards */
-    #include <sys/time.h>
-    #include <sys/types.h>
-    #include <unistd.h>
-
-    int main(void)
-    {
-      fd_set fds;
-      struct timeval t;
-      t.tv_sec = 0;
-      t.tv_usec = 42;
-      FD_ZERO(&fds);
-      /* 0 -> STDIN_FILENO */
-      FD_SET(0, &fds);
-      select(FD_SETSIZE, &fds, NULL, NULL, &t);
-
-      return 0;
-    }
-  ]] HAVE_SELECT)
-cmake_pop_check_state()
-if(HAVE_SELECT)
-  message(CHECK_PASS "yes")
-else()
-  message(CHECK_FAIL "no")
 endif()
 
 ################################################################################

--- a/cmake/sapi/fpm/cmake/CheckClockGetTime.cmake
+++ b/cmake/sapi/fpm/cmake/CheckClockGetTime.cmake
@@ -1,0 +1,80 @@
+#[=============================================================================[
+Check for clock_get*time.
+
+Result variables:
+
+* HAVE_CLOCK_GETTIME
+* HAVE_CLOCK_GET_TIME
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceRuns)
+include(CMakePushCheckState)
+include(PHP/SearchLibraries)
+
+set(HAVE_CLOCK_GETTIME FALSE)
+set(HAVE_CLOCK_GET_TIME FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_CLOCK_GETTIME)
+  if(PHP_SAPI_FPM_HAS_CLOCK_GETTIME)
+    set(HAVE_CLOCK_GETTIME TRUE)
+  endif()
+
+  if(PHP_SAPI_FPM_HAS_CLOCK_GET_TIME)
+    set(HAVE_CLOCK_GET_TIME TRUE)
+  endif()
+
+  return()
+endif()
+
+php_search_libraries(
+  clock_gettime
+  HEADERS time.h
+  LIBRARIES
+    rt # Solaris 10
+  VARIABLE PHP_SAPI_FPM_HAS_CLOCK_GETTIME
+  TARGET php_sapi_fpm PRIVATE
+)
+
+if(PHP_SAPI_FPM_HAS_CLOCK_GETTIME)
+  set(HAVE_CLOCK_GETTIME TRUE)
+else()
+  message(CHECK_START "Checking for clock_get_time()")
+
+  cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_QUIET TRUE)
+    check_source_runs(C [[
+      #include <mach/mach.h>
+      #include <mach/clock.h>
+      #include <mach/mach_error.h>
+
+      int main(void)
+      {
+        kern_return_t ret;
+        clock_serv_t aClock;
+        mach_timespec_t aTime;
+
+        ret = host_get_clock_service(mach_host_self(), REALTIME_CLOCK, &aClock);
+        if (ret != KERN_SUCCESS) {
+          return 1;
+        }
+
+        ret = clock_get_time(aClock, &aTime);
+        if (ret != KERN_SUCCESS) {
+          return 2;
+        }
+
+        return 0;
+      }
+    ]] PHP_SAPI_FPM_HAS_CLOCK_GET_TIME)
+  cmake_pop_check_state()
+
+  if(PHP_SAPI_FPM_HAS_CLOCK_GET_TIME)
+    set(HAVE_CLOCK_GET_TIME TRUE)
+    message(CHECK_PASS "yes")
+  else()
+    message(CHECK_FAIL "no")
+  endif()
+endif()

--- a/cmake/sapi/fpm/cmake/CheckCompilerAtomicBuiltins.cmake
+++ b/cmake/sapi/fpm/cmake/CheckCompilerAtomicBuiltins.cmake
@@ -1,0 +1,43 @@
+#[=============================================================================[
+Check for compiler atomic builtins.
+
+Result variables:
+
+* HAVE_BUILTIN_ATOMIC
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+
+set(HAVE_BUILTIN_ATOMIC FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_BUILTIN_ATOMIC)
+  if(PHP_SAPI_FPM_HAS_BUILTIN_ATOMIC)
+    set(HAVE_BUILTIN_ATOMIC TRUE)
+  endif()
+  return()
+endif()
+
+message(CHECK_START "Checking if compiler has __sync_bool_compare_and_swap")
+
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_source_compiles(C [[
+    int main(void)
+    {
+      int variable = 1;
+      return (__sync_bool_compare_and_swap(&variable, 1, 2)
+            && __sync_add_and_fetch(&variable, 1)) ? 1 : 0;
+    }
+  ]] PHP_SAPI_FPM_HAS_BUILTIN_ATOMIC)
+cmake_pop_check_state()
+
+if(PHP_SAPI_FPM_HAS_BUILTIN_ATOMIC)
+  set(HAVE_BUILTIN_ATOMIC TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
+endif()

--- a/cmake/sapi/fpm/cmake/CheckDevPoll.cmake
+++ b/cmake/sapi/fpm/cmake/CheckDevPoll.cmake
@@ -1,0 +1,53 @@
+#[=============================================================================[
+Check /dev/poll for Solaris < 10
+
+Result variables:
+
+* HAVE_DEVPOLL
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+
+set(HAVE_DEVPOLL FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_DEVPOLL)
+  if(PHP_SAPI_FPM_HAS_DEVPOLL)
+    set(HAVE_DEVPOLL TRUE)
+  endif()
+  return()
+endif()
+
+message(CHECK_START "Checking for /dev/poll")
+
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_source_compiles(C [[
+    #include <stdio.h>
+    #include <sys/devpoll.h>
+
+    int main(void)
+    {
+      int n, dp;
+      struct dvpoll dvp;
+      dp = 0;
+      dvp.dp_fds = NULL;
+      dvp.dp_nfds = 0;
+      dvp.dp_timeout = 0;
+      n = ioctl(dp, DP_POLL, &dvp);
+      (void)n;
+
+      return 0;
+    }
+  ]] PHP_SAPI_FPM_HAS_DEVPOLL)
+cmake_pop_check_state()
+
+if(PHP_SAPI_FPM_HAS_DEVPOLL)
+  set(HAVE_DEVPOLL TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
+endif()

--- a/cmake/sapi/fpm/cmake/CheckEpoll.cmake
+++ b/cmake/sapi/fpm/cmake/CheckEpoll.cmake
@@ -1,0 +1,62 @@
+#[=============================================================================[
+Check epoll.
+
+Result variables:
+
+* HAVE_EPOLL
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+
+set(HAVE_EPOLL FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_EPOLL)
+  if(PHP_SAPI_FPM_HAS_EPOLL)
+    set(HAVE_EPOLL TRUE)
+  endif()
+  return()
+endif()
+
+message(CHECK_START "Checking for epoll")
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_source_compiles(C [[
+    #include <sys/epoll.h>
+
+    int main(void)
+    {
+      int epollfd;
+      struct epoll_event e;
+
+      epollfd = epoll_create(1);
+      if (epollfd < 0) {
+        return 1;
+      }
+
+      e.events = EPOLLIN | EPOLLET;
+      e.data.fd = 0;
+
+      if (epoll_ctl(epollfd, EPOLL_CTL_ADD, 0, &e) == -1) {
+        return 1;
+      }
+
+      e.events = 0;
+      if (epoll_wait(epollfd, &e, 1, 1) < 0) {
+        return 1;
+      }
+
+      return 0;
+    }
+  ]] PHP_SAPI_FPM_HAS_EPOLL)
+cmake_pop_check_state()
+
+if(PHP_SAPI_FPM_HAS_EPOLL)
+  set(HAVE_EPOLL TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
+endif()

--- a/cmake/sapi/fpm/cmake/CheckKqueue.cmake
+++ b/cmake/sapi/fpm/cmake/CheckKqueue.cmake
@@ -1,0 +1,52 @@
+#[=============================================================================[
+Check for kqueue.
+
+Result variables:
+
+* HAVE_KQUEUE
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+
+set(HAVE_KQUEUE FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_KQUEUE)
+  if(PHP_SAPI_FPM_HAS_KQUEUE)
+    set(HAVE_KQUEUE TRUE)
+  endif()
+  return()
+endif()
+
+message(CHECK_START "Checking for kqueue")
+
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_source_compiles(C [[
+    #include <sys/types.h>
+    #include <sys/event.h>
+    #include <sys/time.h>
+
+    int main(void)
+    {
+      int kfd;
+      struct kevent k;
+      kfd = kqueue();
+      /* 0 -> STDIN_FILENO */
+      EV_SET(&k, 0, EVFILT_READ , EV_ADD | EV_CLEAR, 0, 0, NULL);
+      (void)kfd;
+
+      return 0;
+    }
+  ]] PHP_SAPI_FPM_HAS_KQUEUE)
+cmake_pop_check_state()
+
+if(PHP_SAPI_FPM_HAS_KQUEUE)
+  set(HAVE_KQUEUE TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
+endif()

--- a/cmake/sapi/fpm/cmake/CheckListeningQueue.cmake
+++ b/cmake/sapi/fpm/cmake/CheckListeningQueue.cmake
@@ -1,29 +1,12 @@
 #[=============================================================================[
-# CheckListeningQueue
-
 Check FPM listening queue implementation.
 
-## Cache variables
+Result variables:
 
-* `HAVE_LQ_TCP_INFO`
-
-  Whether `TCP_INFO` is present.
-
-* `HAVE_LQ_TCP_CONNECTION_INFO`
-
-  Whether `TCP_CONNECTION_INFO` is present.
-
-* `HAVE_LQ_SO_LISTENQ`
-
-  Whether `SO_LISTENQLEN` and `SO_LISTENQLIMIT` are available as alternative to
-  `TCP_INFO` and `TCP_CONNECTION_INFO`.
-
-## Usage
-
-```cmake
-# CMakeLists.txt
-include(cmake/CheckListeningQueue.cmake)
-```
+* HAVE_LQ_TCP_INFO - Whether TCP_INFO is present.
+* HAVE_LQ_TCP_CONNECTION_INFO - Whether TCP_CONNECTION_INFO is present.
+* HAVE_LQ_SO_LISTENQ - Whether SO_LISTENQLEN and SO_LISTENQLIMIT are available
+  as alternative to TCP_INFO and TCP_CONNECTION_INFO.
 #]=============================================================================]
 
 include_guard(GLOBAL)
@@ -32,62 +15,136 @@ include(CheckSourceCompiles)
 include(CMakePushCheckState)
 include(PHP/SystemExtensions)
 
-message(CHECK_START "Checking FPM listening queue implementation")
+function(_php_sapi_fpm_check_lq_tcp_info result)
+  set(${result} FALSE)
 
-cmake_push_check_state(RESET)
-  # Requires _DEFAULT_SOURCE, which is enabled by _GNU_SOURCE.
-  set(CMAKE_REQUIRED_LIBRARIES PHP::SystemExtensions)
-  check_source_compiles(C [[
-    #include <netinet/tcp.h>
+  if(DEFINED PHP_SAPI_FPM_HAS_LQ_TCP_INFO)
+    if(PHP_SAPI_FPM_HAS_LQ_TCP_INFO)
+      set(${result} TRUE)
+    endif()
 
-    int main(void)
-    {
-      struct tcp_info ti;
-      int x = TCP_INFO;
-      (void)ti;
-      (void)x;
+    return(PROPAGATE ${result})
+  endif()
 
-      return 0;
-    }
-  ]] HAVE_LQ_TCP_INFO)
-cmake_pop_check_state()
+  cmake_push_check_state(RESET)
+    # Requires _DEFAULT_SOURCE, which is enabled by _GNU_SOURCE.
+    set(CMAKE_REQUIRED_LIBRARIES PHP::SystemExtensions)
+    set(CMAKE_REQUIRED_QUIET TRUE)
+
+    check_source_compiles(C [[
+      #include <netinet/tcp.h>
+
+      int main(void)
+      {
+        struct tcp_info ti;
+        int x = TCP_INFO;
+        (void)ti;
+        (void)x;
+
+        return 0;
+      }
+    ]] PHP_SAPI_FPM_HAS_LQ_TCP_INFO)
+  cmake_pop_check_state()
+
+  if(PHP_SAPI_FPM_HAS_LQ_TCP_INFO)
+    set(${result} TRUE)
+  endif()
+
+  return(PROPAGATE ${result})
+endfunction()
 
 # For macOS.
-if(NOT HAVE_LQ_TCP_INFO)
-  check_source_compiles(C [[
-    #include <netinet/tcp.h>
+function(_php_sapi_fpm_check_lq_tcp_connection_info result)
+  set(${result} FALSE)
 
-    int main(void)
-    {
-      struct tcp_connection_info ti;
-      int x = TCP_CONNECTION_INFO;
-      (void)ti;
-      (void)x;
+  if(DEFINED PHP_SAPI_FPM_HAS_LQ_TCP_CONNECTION_INFO)
+    if(PHP_SAPI_FPM_HAS_LQ_TCP_CONNECTION_INFO)
+      set(${result} TRUE)
+    endif()
 
-      return 0;
-    }
-  ]] HAVE_LQ_TCP_CONNECTION_INFO)
-endif()
+    return(PROPAGATE ${result})
+  endif()
+
+  cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_QUIET TRUE)
+
+    check_source_compiles(C [[
+      #include <netinet/tcp.h>
+
+      int main(void)
+      {
+        struct tcp_connection_info ti;
+        int x = TCP_CONNECTION_INFO;
+        (void)ti;
+        (void)x;
+
+        return 0;
+      }
+    ]] PHP_SAPI_FPM_HAS_LQ_TCP_CONNECTION_INFO)
+  cmake_pop_check_state()
+
+  if(PHP_SAPI_FPM_HAS_LQ_TCP_CONNECTION_INFO)
+    set(${result} TRUE)
+  endif()
+
+  return(PROPAGATE ${result})
+endfunction()
 
 # For FreeBSD.
-if(NOT HAVE_LQ_TCP_INFO AND NOT HAVE_LQ_TCP_INFO)
-  check_source_compiles(C [[
-    #include <sys/socket.h>
+function(_php_sapi_fpm_check_lq_so_listenq result)
+  set(${result} FALSE)
 
-    int main(void)
-    {
-      int x = SO_LISTENQLIMIT;
-      int y = SO_LISTENQLEN;
-      (void)x;
-      (void)y;
+  if(DEFINED PHP_SAPI_FPM_HAS_LQ_SO_LISTENQ)
+    if(PHP_SAPI_FPM_HAS_LQ_SO_LISTENQ)
+      set(${result} TRUE)
+    endif()
 
-      return 0;
-    }
-  ]] HAVE_LQ_SO_LISTENQ)
-endif()
+    return(PROPAGATE ${result})
+  endif()
 
-if(HAVE_LQ_TCP_INFO OR HAVE_LQ_TCP_CONNECTION_INFO OR HAVE_LQ_SO_LISTENQ)
-  message(CHECK_PASS "found")
+  cmake_push_check_state(RESET)
+    set(CMAKE_REQUIRED_QUIET TRUE)
+
+    check_source_compiles(C [[
+      #include <sys/socket.h>
+
+      int main(void)
+      {
+        int x = SO_LISTENQLIMIT;
+        int y = SO_LISTENQLEN;
+        (void)x;
+        (void)y;
+
+        return 0;
+      }
+    ]] PHP_SAPI_FPM_HAS_LQ_SO_LISTENQ)
+  cmake_pop_check_state()
+
+  if(PHP_SAPI_FPM_HAS_LQ_SO_LISTENQ)
+    set(${result} TRUE)
+  endif()
+
+  return(PROPAGATE ${result})
+endfunction()
+
+message(CHECK_START "Checking FPM listening queue implementation")
+
+_php_sapi_fpm_check_lq_tcp_info(HAVE_LQ_TCP_INFO)
+
+if(HAVE_LQ_TCP_INFO)
+  message(CHECK_PASS "TCP_INFO")
 else()
-  message(CHECK_FAIL "not found, FPM listening queue is disabled")
+  _php_sapi_fpm_check_lq_tcp_connection_info(HAVE_LQ_TCP_CONNECTION_INFO)
+
+  if(HAVE_LQ_TCP_CONNECTION_INFO)
+    message(CHECK_PASS "TCP_CONNECTION_INFO")
+  else()
+    _php_sapi_fpm_check_lq_so_listenq(HAVE_LQ_SO_LISTENQ)
+
+    if(HAVE_LQ_SO_LISTENQ)
+      message(CHECK_PASS "SO_LISTENQ")
+    else()
+      message(CHECK_FAIL "not found, FPM listening queue is disabled")
+    endif()
+  endif()
 endif()

--- a/cmake/sapi/fpm/cmake/CheckSelect.cmake
+++ b/cmake/sapi/fpm/cmake/CheckSelect.cmake
@@ -1,0 +1,59 @@
+#[=============================================================================[
+Check select.
+
+Result variables:
+
+* HAVE_SELECT
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+include(CheckSourceCompiles)
+include(CMakePushCheckState)
+
+set(HAVE_SELECT FALSE)
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_FPM_HAS_SELECT)
+  if(PHP_SAPI_FPM_HAS_SELECT)
+    set(HAVE_SELECT TRUE)
+  endif()
+  return()
+endif()
+
+message(CHECK_START "Checking for select")
+
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+
+  check_source_compiles(C [[
+    /* According to POSIX.1-2001 */
+    #include <sys/select.h>
+
+    /* According to earlier standards */
+    #include <sys/time.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+
+    int main(void)
+    {
+      fd_set fds;
+      struct timeval t;
+      t.tv_sec = 0;
+      t.tv_usec = 42;
+      FD_ZERO(&fds);
+      /* 0 -> STDIN_FILENO */
+      FD_SET(0, &fds);
+      select(FD_SETSIZE, &fds, NULL, NULL, &t);
+
+      return 0;
+    }
+  ]] PHP_SAPI_FPM_HAS_SELECT)
+cmake_pop_check_state()
+
+if(PHP_SAPI_FPM_HAS_SELECT)
+  set(HAVE_SELECT TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
+endif()

--- a/cmake/sapi/fpm/cmake/CheckTrace.cmake
+++ b/cmake/sapi/fpm/cmake/CheckTrace.cmake
@@ -1,31 +1,14 @@
 #[=============================================================================[
-# CheckTrace
-
 Check FPM trace implementation.
 
-## Cache variables
+Result variables:
 
-* `HAVE_PTRACE`
-
-  Whether `ptrace()` is present and working as expected.
-
-* `HAVE_MACH_VM_READ`
-
-  Whether `ptrace()` didn't work and the `mach_vm_read()` is present.
-
-## Result variables
-
-* `PROC_MEM_FILE`
-
-  If neither `ptrace()` or mach_vm_read()` works, the `/proc/pid/<file>`
-  interface (`mem` or `as`) is set if found and works as expected.
-
-## Usage
-
-```cmake
-# CMakeLists.txt
-include(cmake/CheckTrace.cmake)
-```
+* HAVE_PTRACE - Whether ptrace() is present and works as expected.
+* HAVE_MACH_VM_READ - Whether ptrace() didn't work and the mach_vm_read() is
+  present.
+* PROC_MEM_FILE - If neither ptrace() or mach_vm_read() works, the
+  /proc/pid/<file> interface ('mem' or 'as') is set if found and works as
+  expected.
 #]=============================================================================]
 
 include_guard(GLOBAL)
@@ -35,109 +18,101 @@ include(CheckSourceRuns)
 include(CheckSymbolExists)
 include(CMakePushCheckState)
 
+set(HAVE_PTRACE FALSE)
+set(HAVE_MACH_VM_READ FALSE)
+
 message(CHECK_START "Checking FPM trace implementation")
 
 message(CHECK_START "Checking whether ptrace works")
 
 cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_QUIET TRUE)
-  check_source_compiles(C [[
+  check_source_runs(C [[
+    #include <unistd.h>
+    #include <signal.h>
+    #include <sys/wait.h>
     #include <sys/types.h>
     #include <sys/ptrace.h>
+    #include <errno.h>
+
+    #if !defined(PTRACE_ATTACH) && defined(PT_ATTACH)
+    # define PTRACE_ATTACH PT_ATTACH
+    #endif
+
+    #if !defined(PTRACE_DETACH) && defined(PT_DETACH)
+    # define PTRACE_DETACH PT_DETACH
+    #endif
+
+    #if !defined(PTRACE_PEEKDATA) && defined(PT_READ_D)
+    # define PTRACE_PEEKDATA PT_READ_D
+    #endif
 
     int main(void)
     {
-      ptrace(0, 0, (void *) 0, 0);
-      return 0;
+      /* copy will fail if sizeof(long) == 8 and we've got "int ptrace()" */
+      long v1 = (unsigned int) -1;
+      long v2;
+      pid_t child;
+      int status;
+
+      if ( (child = fork()) ) { /* parent */
+        int ret = 0;
+
+        if (0 > ptrace(PTRACE_ATTACH, child, 0, 0)) {
+          return 2;
+        }
+
+        waitpid(child, &status, 0);
+
+    #ifdef PT_IO
+        struct ptrace_io_desc ptio = {
+          .piod_op = PIOD_READ_D,
+          .piod_offs = &v1,
+          .piod_addr = &v2,
+          .piod_len = sizeof(v1)
+        };
+
+        if (0 > ptrace(PT_IO, child, (void *) &ptio, 0)) {
+          ret = 3;
+        }
+    #else
+        errno = 0;
+
+        v2 = ptrace(PTRACE_PEEKDATA, child, (void *) &v1, 0);
+
+        if (errno) {
+          ret = 4;
+        }
+    #endif
+        ptrace(PTRACE_DETACH, child, (void *) 1, 0);
+
+        kill(child, SIGKILL);
+
+        return ret ? ret : (v1 != v2);
+      } else { /* child */
+        sleep(10);
+        return 0;
+      }
     }
-  ]] PHP_HAS_PTRACE)
+  ]] PHP_SAPI_FPM_HAS_PTRACE)
 cmake_pop_check_state()
 
-if(PHP_HAS_PTRACE)
-  cmake_push_check_state(RESET)
-    set(CMAKE_REQUIRED_QUIET TRUE)
-    check_source_runs(C [[
-      #include <unistd.h>
-      #include <signal.h>
-      #include <sys/wait.h>
-      #include <sys/types.h>
-      #include <sys/ptrace.h>
-      #include <errno.h>
-
-      #if !defined(PTRACE_ATTACH) && defined(PT_ATTACH)
-      # define PTRACE_ATTACH PT_ATTACH
-      #endif
-
-      #if !defined(PTRACE_DETACH) && defined(PT_DETACH)
-      # define PTRACE_DETACH PT_DETACH
-      #endif
-
-      #if !defined(PTRACE_PEEKDATA) && defined(PT_READ_D)
-      # define PTRACE_PEEKDATA PT_READ_D
-      #endif
-
-      int main(void)
-      {
-        /* copy will fail if sizeof(long) == 8 and we've got "int ptrace()" */
-        long v1 = (unsigned int) -1;
-        long v2;
-        pid_t child;
-        int status;
-
-        if ( (child = fork()) ) { /* parent */
-          int ret = 0;
-
-          if (0 > ptrace(PTRACE_ATTACH, child, 0, 0)) {
-            return 2;
-          }
-
-          waitpid(child, &status, 0);
-
-      #ifdef PT_IO
-          struct ptrace_io_desc ptio = {
-            .piod_op = PIOD_READ_D,
-            .piod_offs = &v1,
-            .piod_addr = &v2,
-            .piod_len = sizeof(v1)
-          };
-
-          if (0 > ptrace(PT_IO, child, (void *) &ptio, 0)) {
-            ret = 3;
-          }
-      #else
-          errno = 0;
-
-          v2 = ptrace(PTRACE_PEEKDATA, child, (void *) &v1, 0);
-
-          if (errno) {
-            ret = 4;
-          }
-      #endif
-          ptrace(PTRACE_DETACH, child, (void *) 1, 0);
-
-          kill(child, SIGKILL);
-
-          return ret ? ret : (v1 != v2);
-        } else { /* child */
-          sleep(10);
-          return 0;
-        }
-      }
-    ]] HAVE_PTRACE)
-  cmake_pop_check_state()
-endif()
-
-if(HAVE_PTRACE)
+if(PHP_SAPI_FPM_HAS_PTRACE)
   message(CHECK_PASS "yes")
+  set(HAVE_PTRACE TRUE)
 else()
   message(CHECK_FAIL "no")
+  check_symbol_exists(
+    mach_vm_read
+    "mach/mach.h;mach/mach_vm.h"
+    PHP_SAPI_FPM_HAS_MACH_VM_READ
+  )
+  if(PHP_SAPI_FPM_HAS_MACH_VM_READ)
+    set(HAVE_MACH_VM_READ TRUE)
+  endif()
 endif()
 
-if(NOT HAVE_PTRACE)
-  check_symbol_exists(mach_vm_read "mach/mach.h;mach/mach_vm.h" HAVE_MACH_VM_READ)
-endif()
-
-if(NOT HAVE_PTRACE AND NOT HAVE_MACH_VM_READ)
+if(NOT PHP_SAPI_FPM_HAS_PTRACE AND NOT PHP_SAPI_FPM_HAS_MACH_VM_READ)
   message(CHECK_START "Checking for process memory access file")
 
   if(NOT CMAKE_CROSSCOMPILING)

--- a/cmake/sapi/phpdbg/cmake/CheckTiocgwinsz.cmake
+++ b/cmake/sapi/phpdbg/cmake/CheckTiocgwinsz.cmake
@@ -1,24 +1,12 @@
 #[=============================================================================[
-# CheckTiocgwinsz
+Check if any of the expected headers define TIOCGWINSZ. Some systems define
+TIOCGWINSZ (Terminal Input Output Control Get WINdow SiZe) to obtain the number
+of rows and columns in the terminal window. This is based on Autoconf's
+AC_HEADER_TIOCGWINSZ macro approach.
 
-Check if any of the expected headers define `TIOCGWINSZ`.
+Result variables:
 
-Some systems define `TIOCGWINSZ` (Terminal Input Output Control Get WINdow SiZe)
-to obtain the number of rows and columns in the terminal window. This is based
-on Autoconf's `AC_HEADER_TIOCGWINSZ` macro approach.
-
-## Cache variables
-
-* `GWINSZ_IN_SYS_IOCTL`
-
-  Whether `sys/ioctl.h` defines `TIOCGWINSZ`.
-
-## Usage
-
-```cmake
-# CMakeLists.txt
-include(cmake/CheckTiocgwinsz.cmake)
-```
+* GWINSZ_IN_SYS_IOCTL - Whether <sys/ioctl.h> defines TIOCGWINSZ.
 #]=============================================================================]
 
 include_guard(GLOBAL)
@@ -26,26 +14,50 @@ include_guard(GLOBAL)
 include(CheckSymbolExists)
 include(CMakePushCheckState)
 
+set(GWINSZ_IN_SYS_IOCTL FALSE)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  return()
+endif()
+
+# Skip in consecutive configuration phases.
+if(DEFINED PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_TERMINOS)
+  if(PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_SYS_IOCTL)
+    set(GWINSZ_IN_SYS_IOCTL TRUE)
+  endif()
+  return()
+endif()
+
 message(CHECK_START "Checking whether termios.h defines TIOCGWINSZ")
 cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_QUIET TRUE)
-  check_symbol_exists(TIOCGWINSZ termios.h PHP_HAS_TIOCGWINSZ_IN_TERMIOS_H)
+  check_symbol_exists(
+    TIOCGWINSZ
+    termios.h
+    PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_TERMINOS
+  )
 cmake_pop_check_state()
 
-if(NOT PHP_HAS_TIOCGWINSZ_IN_TERMIOS_H)
-  message(CHECK_FAIL "no")
-
-  message(CHECK_START "Checking whether sys/ioctl.h defines TIOCGWINSZ")
-  cmake_push_check_state(RESET)
-    set(CMAKE_REQUIRED_QUIET TRUE)
-    check_symbol_exists(TIOCGWINSZ sys/ioctl.h GWINSZ_IN_SYS_IOCTL)
-  cmake_pop_check_state()
-
-  if(GWINSZ_IN_SYS_IOCTL)
-    message(CHECK_PASS "yes")
-  else()
-    message(CHECK_FAIL "no")
-  endif()
-else()
+if(PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_TERMINOS)
   message(CHECK_PASS "yes")
+  return()
+endif()
+
+message(CHECK_FAIL "no")
+
+message(CHECK_START "Checking whether sys/ioctl.h defines TIOCGWINSZ")
+cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_QUIET TRUE)
+  check_symbol_exists(
+    TIOCGWINSZ
+    sys/ioctl.h
+    PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_SYS_IOCTL
+  )
+cmake_pop_check_state()
+
+if(PHP_SAPI_PHPDBG_HAS_TIOCGWINSZ_SYS_IOCTL)
+  set(GWINSZ_IN_SYS_IOCTL TRUE)
+  message(CHECK_PASS "yes")
+else()
+  message(CHECK_FAIL "no")
 endif()


### PR DESCRIPTION
This is a recheck of these issues on current systems.

- Cache variable naming conventions synced
- Missing declarations checks refactored with using only compilation checks.