### PR TITLE
Enable testing for standalone extensions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Python
         uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
 
       - name: Install checking tools
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,7 @@ jobs:
             -DPHP_EXT_PHANTOM=ON \
             -DPHP_EXT_PHANTOM_SHARED=ON
           cmake --build cmake-build -j
+          ctest --test-dir cmake-build -j --verbose
           sudo "${{ steps.cmake-and-ninja.outputs.cmake-path }}/cmake" --install cmake-build
           php -d extension=phantom -m | grep phantom
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -193,6 +193,7 @@ configure_package_config_file(
   PATH_VARS
     PHP_EXTENSION_DIR
     PHP_INSTALL_INCLUDEDIR
+    PHP_INSTALL_LIBDIR
 )
 
 # Evaluate hardcoded generator expressions inside variable values.

--- a/cmake/cmake/Configuration.cmake
+++ b/cmake/cmake/Configuration.cmake
@@ -93,6 +93,19 @@ mark_as_advanced(PHP_INCLUDE_PREFIX)
 set(PHP_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/${PHP_INCLUDE_PREFIX})
 
 set(
+  CACHE{PHP_LIB_PREFIX}
+  TYPE STRING
+  HELP
+    "The relative directory inside the CMAKE_INSTALL_LIBDIR, where PHP build "
+    "files are installed. For example, 'php/${PHP_VERSION}' to specify version "
+    "or other build-related characteristics and have multiple PHP versions "
+    "installed. Absolute paths are treated as relative; set "
+    "CMAKE_INSTALL_LIBDIR if absolute path needs to be set."
+  VALUE "php"
+)
+set(PHP_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${PHP_LIB_PREFIX})
+
+set(
   CACHE{PHP_CONFIG_FILE_SCAN_DIR}
   TYPE STRING
   HELP

--- a/cmake/cmake/Extensions.cmake
+++ b/cmake/cmake/Extensions.cmake
@@ -392,30 +392,6 @@ function(php_extensions_postconfigure extension)
       )
     endif()
   endforeach()
-
-  # Configure shared extension.
-  get_target_property(type php_ext_${extension} TYPE)
-  if(NOT type MATCHES "^(MODULE|SHARED)_LIBRARY$")
-    return()
-  endif()
-
-  # Set build-phase location for shared extensions.
-  get_target_property(location php_ext_${extension} LIBRARY_OUTPUT_DIRECTORY)
-  if(NOT location)
-    get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-
-    if(is_multi_config)
-      set_property(
-        TARGET php_ext_${extension}
-        PROPERTY LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/modules"
-      )
-    else()
-      set_property(
-        TARGET php_ext_${extension}
-        PROPERTY LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/modules/$<CONFIG>"
-      )
-    endif()
-  endif()
 endfunction()
 
 # Validate extensions and their dependencies defined via add_dependencies().

--- a/cmake/cmake/PHPConfig.cmake.in
+++ b/cmake/cmake/PHPConfig.cmake.in
@@ -151,6 +151,7 @@ endif()
 
 set_and_check(PHP_EXTENSION_DIR "@PACKAGE_PHP_EXTENSION_DIR@")
 set_and_check(PHP_INSTALL_INCLUDEDIR "@PACKAGE_PHP_INSTALL_INCLUDEDIR@")
+set_and_check(PHP_INSTALL_LIBDIR "@PACKAGE_PHP_INSTALL_LIBDIR@")
 
 # Set path where additional PHP CMake modules are installed:
 set(PHP_CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")

--- a/cmake/cmake/modules/PHP/Internal/Testing.cmake
+++ b/cmake/cmake/modules/PHP/Internal/Testing.cmake
@@ -1,0 +1,106 @@
+#[=============================================================================[
+This is an internal module and is not intended for direct usage inside projects.
+It provides PHP testing configuration.
+
+Load this module in a PHP CMake project or inside a module with:
+
+  include(PHP/Internal/Testing)
+
+Commands
+
+This module provides the following commands:
+
+_php_testing_add_test()
+
+  Adds CMake test via add_test() for running run-tests.php script:
+
+    _php_testing_add_test(<extensions>)
+
+  The arguments are:
+
+  * <extensions> - A semicolon-separated list of one or more PHP extensions.
+#]=============================================================================]
+
+include_guard(GLOBAL)
+
+function(_php_testing_add_test extensions)
+  if(TARGET PHP::sapi::cli)
+    set(php_executable "PHP::sapi::cli")
+    set(run_tests "run-tests.php")
+    set(extension_dir "${PHP_BINARY_DIR}/modules")
+    set(working_dir "${PHP_SOURCE_DIR}")
+  elseif(TARGET PHP::Interpreter)
+    set(php_executable "PHP::Interpreter")
+
+    if(NOT EXISTS ${PHP_INSTALL_LIBDIR}/build/run-tests.php)
+      message(
+        WARNING
+        "'${PHP_INSTALL_LIBDIR}/build/run-tests.php' is missing. "
+        "Default tests for the ${extension} extension are not configured."
+      )
+      return()
+    endif()
+
+    # Copy run-tests.php to the current binary directory as it writes some
+    # temporary files inside its containing directory.
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PHP)
+    file(
+      COPY
+      ${PHP_INSTALL_LIBDIR}/build/run-tests.php
+      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PHP
+    )
+
+    set(run_tests "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PHP/run-tests.php")
+    set(extension_dir "${CMAKE_CURRENT_BINARY_DIR}/modules")
+    set(working_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+  else()
+    return()
+  endif()
+
+  get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(NOT is_multi_config)
+    string(APPEND extension_dir "/$<CONFIG>")
+  endif()
+
+  cmake_host_system_information(RESULT processors QUERY NUMBER_OF_LOGICAL_CORES)
+
+  set(parallel "")
+  if(processors)
+    set(parallel -j${processors})
+  endif()
+
+  set(options "")
+  foreach(extension IN LISTS extensions)
+    get_target_property(type PHP::ext::${extension} TYPE)
+    if(type MATCHES "^(MODULE|SHARED)_LIBRARY$")
+      get_target_property(
+        is_zend_extension
+        PHP::ext::${extension}
+        PHP_ZEND_EXTENSION
+      )
+      if(is_zend_extension)
+        list(APPEND options -d zend_extension=${extension})
+      elseif(NOT extension STREQUAL "dl_test")
+        list(APPEND options -d extension=${extension})
+      endif()
+    endif()
+  endforeach()
+
+  add_test(
+    NAME PHP
+    COMMAND
+      ${php_executable}
+        -n
+        -d open_basedir=
+        -d output_buffering=0
+        -d memory_limit=-1
+        ${run_tests}
+          -n
+          -d extension_dir=${extension_dir}
+          --show-diff
+          ${options}
+          ${parallel}
+          -q
+    WORKING_DIRECTORY ${working_dir}
+  )
+endfunction()

--- a/cmake/scripts/CMakeLists.txt
+++ b/cmake/scripts/CMakeLists.txt
@@ -226,7 +226,7 @@ install(
     ${PHP_SOURCE_DIR}/build/pkg.m4
     ${PHP_SOURCE_DIR}/run-tests.php
     ${PHP_SOURCE_DIR}/scripts/phpize.m4
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/php/build
+  DESTINATION ${PHP_INSTALL_LIBDIR}/build
   COMPONENT php-development
 )
 
@@ -235,6 +235,6 @@ install(
     ${PHP_SOURCE_DIR}/build/config.guess
     ${PHP_SOURCE_DIR}/build/config.sub
     ${PHP_SOURCE_DIR}/build/shtool
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/php/build
+  DESTINATION ${PHP_INSTALL_LIBDIR}/build
   COMPONENT php-development
 )

--- a/cmake/tests/CMakeLists.txt
+++ b/cmake/tests/CMakeLists.txt
@@ -6,49 +6,9 @@ include(CheckLinkerFlag)
 include(FeatureSummary)
 
 # Add test for all *.phpt files.
-if(TARGET PHP::sapi::cli)
-  cmake_host_system_information(RESULT processors QUERY NUMBER_OF_LOGICAL_CORES)
-
-  set(parallel "")
-  if(processors)
-    set(parallel -j${processors})
-  endif()
-
-  get_property(extensions GLOBAL PROPERTY PHP_EXTENSIONS)
-  foreach(extension IN LISTS extensions)
-    get_target_property(type PHP::ext::${extension} TYPE)
-    if(type MATCHES "^(MODULE|SHARED)_LIBRARY$")
-      get_target_property(
-        is_zend_extension
-        PHP::ext::${extension}
-        PHP_ZEND_EXTENSION
-      )
-      if(is_zend_extension)
-        list(APPEND options -d zend_extension=${extension})
-      elseif(NOT extension STREQUAL "dl_test")
-        list(APPEND options -d extension=${extension})
-      endif()
-    endif()
-  endforeach()
-
-  add_test(
-    NAME PHP
-    COMMAND
-      PHP::sapi::cli
-        -n
-        -d open_basedir=
-        -d output_buffering=0
-        -d memory_limit=-1
-        run-tests.php
-          -n
-          -d extension_dir=${PHP_BINARY_DIR}/modules/$<CONFIG>
-          --show-diff
-          ${options}
-          ${parallel}
-          -q
-    WORKING_DIRECTORY ${PHP_SOURCE_DIR}
-  )
-endif()
+include(PHP/Internal/Testing)
+get_property(extensions GLOBAL PROPERTY PHP_EXTENSIONS)
+_php_testing_add_test("${extensions}")
 
 if(NOT TARGET PHP::sapi::embed)
   return()


### PR DESCRIPTION
This adds a test for running run-tests.php script when building PHP
via php-src repository and for standalone extensions built outside of
php-src.

Additionally:
- Adjusted GitHub actions configuration.